### PR TITLE
Remove unref causing a segfault.

### DIFF
--- a/example/timer.c
+++ b/example/timer.c
@@ -22,7 +22,6 @@ main()
 )_(   c -= 1
 )_(   if c < 0
 )_(     t.close()
-)_(     UV.default_loop().unref()
 )_(   end
 )_( }
 )_( UV.run()


### PR DESCRIPTION
The timer is no longer active so the refcount becomes -1 and was triggering an assert.
