### PR TITLE
fixed osx compilation

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -9,6 +9,10 @@ MRuby::Gem::Specification.new('mruby-uv') do |spec|
       spec.linker.flags << "-L" + ENV['libuv_path']
       spec.cc.flags << '-I"#{ENV["libuv_path"] + "/include"}"'
     end
-    spec.linker.libraries << ['uv', 'rt', 'm']
+    spec.linker.libraries << ['uv', 'm']
+    
+    unless RUBY_PLATFORM.include?('darwin')
+      spec.linker.libraries << 'rt'
+    end
   end
 end


### PR DESCRIPTION
-lrt does not exists on Mac OS X.

I wasn't sure how to test the platform but since this script is executed by a "full" ruby interpreter I figured RUBY_PLATFORM was a pretty straight forward solution.

( ENV['OS'] is undefined for me )
