### PR TITLE
Force cfunc in queue_work's work_cb and add test for it.

### DIFF
--- a/test/uv.c
+++ b/test/uv.c
@@ -1,4 +1,5 @@
 #include "mruby.h"
+#include "mruby/proc.h"
 #include <signal.h>
 
 static mrb_value raise_signal(mrb_state* mrb, mrb_value self) {
@@ -8,6 +9,23 @@ static mrb_value raise_signal(mrb_state* mrb, mrb_value self) {
   return mrb_fixnum_value(raise(sig));
 }
 
+static mrb_int count;
+static mrb_value work_cfunc(mrb_state *mrb, mrb_value self) {
+  int i;
+  mrb_assert(mrb == NULL);
+  mrb_assert(mrb_nil_p(self));
+  for (i = 0; i < 100; ++i) {
+    count += i;
+  }
+  return self;
+}
+
+static mrb_value get_work_result(mrb_state *mrb, mrb_value self) {
+  return mrb_fixnum_value(count);
+}
+
 void mrb_mruby_uv_gem_test(mrb_state* mrb) {
   mrb_define_method(mrb, mrb->object_class, "raise_signal", raise_signal, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, mrb->kernel_module, "get_work_result", get_work_result, MRB_ARGS_NONE());
+  mrb_define_const(mrb, mrb->object_class, "WorkCFunc", mrb_obj_value(mrb_proc_new_cfunc(mrb, work_cfunc)));
 }

--- a/test/uv.rb
+++ b/test/uv.rb
@@ -96,7 +96,12 @@ end
 
 assert('UV.queue_work') do
   c = 0
-  UV.queue_work { c += 1 }
+  assert_raise(ArgumentError) { UV.queue_work(Proc.new {}) {} }
+  assert_raise(ArgumentError) { UV.queue_work(WorkCFunc) }
+  UV.queue_work(WorkCFunc) {
+    assert_equal 4950, get_work_result
+    c += 1
+  }
   UV.run
   assert_equal 1, c
 end


### PR DESCRIPTION
This changes is to make API `UV.queue_work` more safer.
Since `uv_work_cb` would be always runned on separate thread as mruby runs, running block on it will break running context of mruby.
On new mruby-uv `uv_work_cb`, it can only run cfunc proc that can run separately with `mrb_state` that is passed to `UV.queue_work` as argument.
(The cfunc would be called with arguments `NULL, mrb_nil_value()` and returned value would be discarded.)
And the block passed to `UV.queue_work` would be runned on `uv_after_work_cb`.
(See the test codes for detail. It will run summing of 0 to 99 on other thread.)
