### PR TITLE
Fix and improve mode flag.

### DIFF
--- a/src/fs.c
+++ b/src/fs.c
@@ -1031,6 +1031,7 @@ void mrb_mruby_uv_gem_init_fs(mrb_state *mrb, struct RClass *UV)
 #endif
   mrb_define_const(mrb, _class_uv_fs, "S_IWRITE", mrb_fixnum_value(S_IWUSR));
   mrb_define_const(mrb, _class_uv_fs, "S_IREAD", mrb_fixnum_value(S_IRUSR));
+  mrb_define_const(mrb, _class_uv_fs, "S_IEXEC", mrb_fixnum_value(S_IXUSR));
   mrb_define_method(mrb, _class_uv_fs, "write", mrb_uv_fs_write, ARGS_REQ(1) | ARGS_OPT(2));
   mrb_define_method(mrb, _class_uv_fs, "read", mrb_uv_fs_read, ARGS_REQ(0) | ARGS_OPT(2));
   mrb_define_method(mrb, _class_uv_fs, "datasync", mrb_uv_fs_fdatasync, ARGS_NONE());

--- a/src/mrb_uv.h
+++ b/src/mrb_uv.h
@@ -73,6 +73,9 @@ mrb_value mrb_uv_from_uint64(mrb_state *mrb, uint64_t v);
 #  ifndef S_IWUSR
 #    define S_IWUSR _S_IWRITE
 #  endif
+#  ifndef S_IXUSR
+#    define S_IXUSR _S_IEXEC
+#  endif
 #endif
 
 #endif


### PR DESCRIPTION
Since `S_IEXEC`, `S_IWRITE`, `S_IREAD` is BSD extension it can't be used in some POSIX env.
So replaced it with POSIX name.
Added `S_IXUSR` binding too.

(The travis fail is related to: https://github.com/mruby/mruby/pull/2222 )
