### PR TITLE
Update libuv version to 0.11.29.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ MIT
 libuv
 -----
 
-Current mruby-uv use [libuv-v0.11.28](http://libuv.org/dist/v0.11.28/libuv-v0.11.28.tar.gz).
+Current mruby-uv use [libuv-v0.11.29](http://libuv.org/dist/v0.11.29/libuv-v0.11.29.tar.gz).
 In Windows mruby-uv doesn't provide libuv builder so install it before you use this.
 In OS X install it with `brew install libuv --devel` to reduce build time.

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -23,7 +23,7 @@ MRuby::Gem::Specification.new('mruby-uv') do |spec|
 
   require 'open3'
 
-  version = '0.11.28'
+  version = '0.11.29'
   libuv_dir = "#{build_dir}/libuv-#{version}"
   libuv_lib = libfile "#{libuv_dir}/.libs/libuv"
   header = "#{libuv_dir}/include/uv.h"

--- a/src/handle.c
+++ b/src/handle.c
@@ -153,6 +153,48 @@ mrb_uv_has_ref(mrb_state *mrb, mrb_value self)
   return mrb_bool_value(uv_has_ref(&ctx->handle));
 }
 
+static mrb_value
+mrb_uv_recv_buffer_size(mrb_state *mrb, mrb_value self)
+{
+  mrb_uv_handle *ctx = (mrb_uv_handle*)mrb_uv_get_ptr(mrb, self, &mrb_uv_handle_type);
+  int v = 0;
+  mrb_uv_check_error(mrb, uv_recv_buffer_size(&ctx->handle, &v));
+  return mrb_fixnum_value(v);
+}
+
+static mrb_value
+mrb_uv_recv_buffer_size_set(mrb_state *mrb, mrb_value self)
+{
+  mrb_uv_handle *ctx = (mrb_uv_handle*)mrb_uv_get_ptr(mrb, self, &mrb_uv_handle_type);
+  mrb_int tmp_v;
+  int v;
+  mrb_get_args(mrb, "i", &tmp_v);
+  v = tmp_v;
+  mrb_uv_check_error(mrb, uv_recv_buffer_size(&ctx->handle, &v));
+  return self;
+}
+
+static mrb_value
+mrb_uv_send_buffer_size(mrb_state *mrb, mrb_value self)
+{
+  mrb_uv_handle *ctx = (mrb_uv_handle*)mrb_uv_get_ptr(mrb, self, &mrb_uv_handle_type);
+  int v = 0;
+  mrb_uv_check_error(mrb, uv_send_buffer_size(&ctx->handle, &v));
+  return mrb_fixnum_value(v);
+}
+
+static mrb_value
+mrb_uv_send_buffer_size_set(mrb_state *mrb, mrb_value self)
+{
+  mrb_uv_handle *ctx = (mrb_uv_handle*)mrb_uv_get_ptr(mrb, self, &mrb_uv_handle_type);
+  mrb_int tmp_v;
+  int v;
+  mrb_get_args(mrb, "i", &tmp_v);
+  v = tmp_v;
+  mrb_uv_check_error(mrb, uv_send_buffer_size(&ctx->handle, &v));
+  return self;
+}
+
 /*********************************************************
  * UV::Pipe
  *********************************************************/
@@ -1856,6 +1898,10 @@ mrb_mruby_uv_gem_init_handle(mrb_state *mrb, struct RClass *UV)
   mrb_define_method(mrb, _class_uv_handle, "has_ref?", mrb_uv_has_ref, MRB_ARGS_NONE());
   mrb_define_method(mrb, _class_uv_handle, "data=", mrb_uv_data_set, ARGS_REQ(1));
   mrb_define_method(mrb, _class_uv_handle, "data", mrb_uv_data_get, ARGS_NONE());
+  mrb_define_method(mrb, _class_uv_handle, "recv_buffer_size", mrb_uv_recv_buffer_size, MRB_ARGS_NONE());
+  mrb_define_method(mrb, _class_uv_handle, "recv_buffer_size=", mrb_uv_recv_buffer_size_set, MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, _class_uv_handle, "send_buffer_size", mrb_uv_send_buffer_size, MRB_ARGS_NONE());
+  mrb_define_method(mrb, _class_uv_handle, "send_buffer_size=", mrb_uv_send_buffer_size_set, MRB_ARGS_REQ(1));
 
   _class_uv_stream = mrb_define_module_under(mrb, UV, "Stream");
   mrb_include_module(mrb, _class_uv_stream, _class_uv_handle);

--- a/test/callback.rb
+++ b/test/callback.rb
@@ -49,15 +49,15 @@ assert_uv 'UV::FS.readdir' do
   f.close
 
   # async version
-  UV::FS.readdir 'foo-bar', 0 do |x, a|
-    assert_equal ['bar.txt', 'foo.txt'], a.sort
+  UV::FS.readdir 'foo-bar', 0 do |a|
+    assert_equal [['bar.txt', :file], ['foo.txt', :file]], a.sort
 
     remove_uv_test_tmpfile
   end
 
   # sync version
   a = UV::FS.readdir 'foo-bar', 0
-  assert_equal ['bar.txt', 'foo.txt'], a.sort
+  assert_equal [['bar.txt', :file], ['foo.txt', :file]], a.sort
 end
 
 assert_uv 'UV::FS.symlink' do
@@ -210,6 +210,14 @@ assert_uv 'UV::Pipe' do
     c.close
     s.close
   end
+
+  assert_kind_of Fixnum, s.recv_buffer_size
+  s.recv_buffer_size = 0x10000
+  assert_true s.recv_buffer_size >= 0x10000
+
+  assert_kind_of Fixnum, s.send_buffer_size
+  s.send_buffer_size = 0x10000
+  assert_true s.send_buffer_size >= 0x10000
 
   client = UV::Pipe.new(1)
   client.connect path do |x|


### PR DESCRIPTION
The behavior of `UV::FS.readdir` changes. It will create array with file type instead of only names to follow latest libuv.
