### PR TITLE
specify where deps come from

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -2,8 +2,8 @@ MRuby::Gem::Specification.new('mruby-uv') do |spec|
   spec.license = 'MIT'
   spec.authors = 'mattn'
   spec.summary = 'libuv mruby binding'
-  spec.add_dependency 'mruby-time'
-  spec.add_dependency 'mruby-sprintf'
+  spec.add_dependency 'mruby-time',    core: 'mruby-time'
+  spec.add_dependency 'mruby-sprintf', core: 'mruby-sprintf'
 
   is_cross = build.kind_of? MRuby::CrossBuild
 


### PR DESCRIPTION
mruby build now supports specifying where builds come from. this sets it so when users use your mrbgem they don't need to do it.