### PR TITLE
Getaddrinfo hints

### DIFF
--- a/test/uv.rb
+++ b/test/uv.rb
@@ -143,3 +143,24 @@ assert 'UV.thread_self' do
   s = UV.thread_self
   assert_equal s, s
 end
+
+assert 'UV.getaddrinfo ipv4' do
+  UV::getaddrinfo('google.com', 'http', {:ai_family => :ipv4}) do |x, info|
+    assert_true(info.addr.is_a?(UV::Ip4Addr), "Expected UV::Ip4Addr but got #{info.addr.class}")
+  end
+  UV::run()
+end
+
+assert 'UV.getaddrinfo ipv6' do
+  UV::getaddrinfo('google.com', 'http', {:ai_family => :ipv6}) do |x, info|
+    assert_true(info.addr.is_a?(UV::Ip6Addr), "Expected UV::Ip4Addr but got #{info.addr.class}")
+  end
+  UV::run()
+end
+
+assert 'UV.getaddrinfo' do
+  req = UV::getaddrinfo('google.com', 'http') {}
+  UV::run()
+
+  assert_true req.is_a?(UV::Req)
+end


### PR DESCRIPTION
In [mruby-simplehttp](https://github.com/matsumoto-r/mruby-simplehttp), it uses `UV::getaddrinfo` to get the ip information. I was at a friends place, that forces ipv6 dns resolution which broke mruby-simplehttp. In mruby-simplehttp we'll need to do something like [this](https://github.com/hone/mruby-simplehttp/commit/6a53e057e600a9840a0ec7130b0f8a423d4d4ba5) with this PR. Normally, you can pass a `hints` argument to coerce the `getaddrinfo`. This patch allows someone to pass in a `hints` hash.

I added some unit tests for this functionality, but I'm not sure if you want unit tests that hit the network, but I couldn't figure out a good way to test DNS resolution without it.