### PR TITLE
Assign mruby nil to loop on initialize in UV::Poll.new

### DIFF
--- a/src/handle.c
+++ b/src/handle.c
@@ -1819,7 +1819,7 @@ static mrb_value
 mrb_uv_poll_init(mrb_state *mrb, mrb_value self)
 {
   mrb_uv_handle *ctx;
-  mrb_value fd, loop;
+  mrb_value fd, loop = mrb_nil_value();
   mrb_get_args(mrb, "o|o", &fd, &loop);
 
   ctx = mrb_uv_handle_alloc(mrb, sizeof(uv_poll_t), self);


### PR DESCRIPTION
`UV::Poll.new` 's second argument is optional, and it seems not initialized in the proper way.

```ruby
r, w = IO.pipe
UV::Poll.new(r.fileno)
```

This causes SEGV.

```ruby
r, w = IO.pipe
UV::Poll.new(r.fileno, UV.default_loop)
```

This works, but it should behave like `UV::Poll.new(r.fileno)`