### PR TITLE
Zero out all fields of addrinfo hints

### DIFF
--- a/src/mrb_uv.c
+++ b/src/mrb_uv.c
@@ -533,7 +533,7 @@ mrb_uv_getaddrinfo(mrb_state *mrb, mrb_value self)
   mrb_value node, service, b = mrb_nil_value(), req_val;
   mrb_value mrb_hints = mrb_hash_new(mrb);
   mrb_uv_req_t* req;
-  struct addrinfo hints;
+  struct addrinfo hints = {0};
   hints.ai_family = AF_UNSPEC;
   hints.ai_socktype = 0;
   hints.ai_protocol = 0;


### PR DESCRIPTION
getaddrinfo(3) explicitly says these fields have to be zero:

> All the other fields in the structure pointed to by hints
> must contain either 0 or a null pointer, as appropriate.

FreeBSD will fail with EAI_BADHINTS as hints contain garbage:
https://github.com/freebsd/freebsd/blob/29cbcfe994c6984bf993b7587b429668ce5073a8/lib/libc/net/getaddrinfo.c#L429-L431