### PR TITLE
Fix compilation error

### DIFF
--- a/src/mrb_uv.c
+++ b/src/mrb_uv.c
@@ -28,7 +28,7 @@ mrb_uv_gc_table_clean(mrb_state *mrb)
       ary[new_i++] = ary[i];
     }
   }
-  RARRAY_LEN(t) = new_i;
+  RARRAY_SET_LEN(t, new_i);
 }
 
 void

--- a/src/mrb_uv.h
+++ b/src/mrb_uv.h
@@ -27,6 +27,20 @@
 #define mrb_uv_args_int mrb_int
 #endif
 
+#ifdef ARY_SET_LEN
+#define RARRAY_SET_LEN(ary, len) do {\
+  struct RArray *a = mrb_ary_ptr(ary);\
+  ARY_SET_LEN(a, len);\
+} while(0)
+#else
+#define RARRAY_SET_LEN(ary, len) do {\
+  RARRAY_LEN(ary) = len;\
+} while (0)
+#endif
+#ifndef ARY_PTR
+#define ARY_PTR(a) (a->ptr)
+#endif
+
 #define symbol_value_lit(mrb, lit) (mrb_symbol_value(mrb_intern_lit(mrb, lit)))
 
 extern const struct mrb_data_type mrb_uv_ip4addr_type;

--- a/src/thread.c
+++ b/src/thread.c
@@ -565,10 +565,10 @@ mrb_uv_key_set(mrb_state *mrb, mrb_value self)
     for (i = 0, dst = 0; i < RARRAY_LEN(ary); ++i) {
       mrb_value v = RARRAY_PTR(ary)[i];
       if (mrb_ptr(v) != p) {
-        mrb_ary_ptr(ary)->ptr[dst++] = v;
+        ARY_PTR(mrb_ary_ptr(ary))[dst++] = v;
       }
     }
-    RARRAY_LEN(ary) = dst;
+    RARRAY_SET_LEN(ary, dst);
   }
 
   uv_key_set(key, mrb_ptr(new_val));


### PR DESCRIPTION
I cannot build mruby master (7b88c1a8e5e7316c1ddad6fc63c2a90678a146fc) with mruby-uv (39a9b2e30513094266763403bf115a8f6dad617a).

This pull-request fixes it.

### Why WIP?

I ran test on TravisCI. But mruby-1.0.0 with mruby-uv cannot build. https://travis-ci.org/nishidayuya/mruby-uv/jobs/260113711#L713-L717

Umm... Does mruby-uv still support mruby-1.0.0? Or, I can fix .travis.yml to use mruby-1.3.0.

### Setup and my environment

```shell
% VBoxManage --version
4.3.36_Debianr105129
% vagrant --version
Vagrant 1.9.7
% cat Vagrantfile
# -*- mode: ruby -*-
# vi: set ft=ruby :

Vagrant.configure("2") do |config|
  config.vm.box = "debian/stretch64"
  config.vm.provider(:virtualbox) do |v|
    v.cpus = 1
    v.memory = 512
  end
  config.vm.provision(:shell, inline: <<-SHELL)
set -xe

export DEBIAN_FRONTEND=noninteractive
apt-get update
apt-get install -y ruby git build-essential bison curl automake libtool

cd ~vagrant/
sudo -u vagrant tee before-build_config.rb > /dev/null <<EOS
MRuby::Build.new do |conf|
  toolchain(:gcc)
  conf.gembox("default")
  conf.gem(mgem: "mruby-uv")
  conf.enable_test
end
EOS
sudo -u vagrant tee after-build_config.rb > /dev/null <<EOS
MRuby::Build.new do |conf|
  toolchain(:gcc)
  conf.gembox("default")
  conf.gem(github: "nishidayuya/mruby-uv", branch: "fix_compilation_error")
  conf.enable_test
end
EOS
sudo -u vagrant git clone https://github.com/mruby/mruby.git
  SHELL
end
% vagrant up && vagrant ssh
...
vagrant@stretch:~$ cd mruby/
vagrant@stretch:~/mruby$ git rev-parse HEAD
7b88c1a8e5e7316c1ddad6fc63c2a90678a146fc
```

### Before pull-request

```sh
vagrant@stretch:~/mruby$ cp -a ../before-build_config.rb build_config.rb
vagrant@stretch:~/mruby$ rm -rf build && ./minirake all
...
  CC       src/unix/libuv_la-linux-inotify.lo
  CC       src/unix/libuv_la-linux-syscalls.lo
  CC       src/unix/libuv_la-proctitle.lo
  CCLD     libuv.la
ar: `u' modifier ignored since `D' is the default (see `U')
CC    build/mrbgems/mruby-uv/src/thread.c -> build/host/mrbgems/mruby-uv/src/thread.o
/home/vagrant/mruby/build/mrbgems/mruby-uv/src/thread.c: In function ‘mrb_uv_key_set’:
/home/vagrant/mruby/build/mrbgems/mruby-uv/src/thread.c:568:25: error: ‘struct RArray’ has no member named ‘ptr’
         mrb_ary_ptr(ary)->ptr[dst++] = v;
                         ^~
/home/vagrant/mruby/build/mrbgems/mruby-uv/src/thread.c:571:21: error: lvalue required as left operand of assignment
     RARRAY_LEN(ary) = dst;
                     ^
/home/vagrant/mruby/build/mrbgems/mruby-uv/src/thread.c: In function ‘mrb_uv_key_set’:
/home/vagrant/mruby/build/mrbgems/mruby-uv/src/thread.c:568:25: error: ‘struct RArray’ has no member named ‘ptr’
         mrb_ary_ptr(ary)->ptr[dst++] = v;
                         ^~
/home/vagrant/mruby/build/mrbgems/mruby-uv/src/thread.c:571:21: error: lvalue required as left operand of assignment
     RARRAY_LEN(ary) = dst;
                     ^
rake aborted!
Command Failed: [gcc -g -std=gnu99 -O3 -Wall -Werror-implicit-function-declaration -Wdeclaration-after-statement -Wwrite-strings -DMRBGEM_MRUBY_UV_VERSION=0.0.0 -I"/home/vagrant/mruby/include" -I"/home/vagrant/mruby/build/host/mrbgems/mruby-uv/libuv-1.0.0/include" -I"/home/vagrant/mruby/build/mrbgems/mruby-uv/include" -MMD -o "/home/vagrant/mruby/build/host/mrbgems/mruby-uv/src/thread.o" -c "/home/vagrant/mruby/build/mrbgems/mruby-uv/src/thread.c"]
```

### After pull-request

```sh
vagrant@stretch:~/mruby$ cp -a ../after-build_config.rb build_config.rb
vagrant@stretch:~/mruby$ rm -rf build && ./minirake all
...
CC    mrbgems/mruby-bin-strip/tools/mruby-strip/mruby-strip.c -> build/host/mrbgems/mruby-bin-strip/tools/mruby-strip/mruby-strip.o
LD    build/host/bin/mruby-strip

Build summary:

================================================
      Config Name: host
 Output Directory: build/host
         Binaries: mrbc, mrbtest
    Included Gems:
             mruby-sprintf - standard Kernel#sprintf method
             mruby-print - standard print/puts/p
             mruby-math - standard Math module
             mruby-time - standard Time class
             mruby-struct - standard Struct class
             mruby-enum-ext - Enumerable module extension
             mruby-fiber - Fiber class
             mruby-enumerator - Enumerator class
             mruby-string-ext - String class extension
             mruby-numeric-ext - Numeric class extension
             mruby-array-ext - Array class extension
             mruby-hash-ext - Hash class extension
             mruby-range-ext - Range class extension
             mruby-proc-ext - Proc class extension
             mruby-symbol-ext - Symbol class extension
             mruby-random - Random class
             mruby-object-ext - Object class extension
             mruby-objectspace - ObjectSpace class
             mruby-enum-lazy - Enumerator::Lazy class
             mruby-toplevel-ext - toplevel object (main) methods extension
             mruby-compiler - mruby compiler library
             mruby-bin-mirb - mirb command
               - Binaries: mirb
             mruby-error - extensional error handling
             mruby-bin-mruby - mruby command
               - Binaries: mruby
             mruby-bin-strip - irep dump debug section remover command
               - Binaries: mruby-strip
             mruby-kernel-ext - Kernel module extension
             mruby-class-ext - class/module extension
             mruby-uv - libuv mruby binding
             mruby-bin-mrbc - mruby compiler executable
             mruby-test - mruby test
================================================

vagrant@stretch:~/mruby$ cd build/mrbgems/mruby-uv/
vagrant@stretch:~/mruby/build/mrbgems/mruby-uv$ git rev-parse HEAD
39a9b2e30513094266763403bf115a8f6dad617a
```
