### PR TITLE
Refactor getaddrinfo.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 script:
   - export MRUBY_CONFIG="$TRAVIS_BUILD_DIR/.travis_config.rb"
   - git clone --depth 1 "https://github.com/mruby/mruby.git"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,23 @@
 sudo: false
+addons:
+  apt:
+    packages:
+      - gperf
+compiler:
+  - gcc
+  - clang
+env:
+  matrix:
+    - MRUBY_VERSION=master
+    - MRUBY_VERSION=1.2.0
+    - MRUBY_VERSION=1.3.0
 script:
   - export MRUBY_CONFIG="$TRAVIS_BUILD_DIR/.travis_config.rb"
-  - git clone --depth 1 "https://github.com/mruby/mruby.git"
-  - cd mruby
-  - ./minirake all test
-
-  - cd "$TRAVIS_BUILD_DIR"
-  - curl -L "https://github.com/mruby/mruby/archive/1.2.0.tar.gz" > mruby-1.2.0.tar.gz
-  - tar xf mruby-1.2.0.tar.gz
-  - cd mruby-1.2.0
-  - ./minirake all test
-
-  - cd "$TRAVIS_BUILD_DIR"
-  - curl -L "https://github.com/mruby/mruby/archive/1.3.0.tar.gz" > mruby-1.3.0.tar.gz
-  - tar xf mruby-1.3.0.tar.gz
-  - cd mruby-1.3.0
+  - 'if [ "$MRUBY_VERSION" = "master" ] ; then
+      git clone --depth 1 "https://github.com/mruby/mruby.git" mruby-$MRUBY_VERSION;
+    else
+      curl -L "https://github.com/mruby/mruby/archive/$MRUBY_VERSION.tar.gz" > mruby-$MRUBY_VERSION.tar.gz:
+      tar xf mruby-$MRUBY_VERSION.tar.gz;
+    fi'
+  - cd mruby-$MRUBY_VERSION
   - ./minirake all test

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - 'if [ "$MRUBY_VERSION" = "master" ] ; then
       git clone --depth 1 "https://github.com/mruby/mruby.git" mruby-$MRUBY_VERSION;
     else
-      curl -L "https://github.com/mruby/mruby/archive/$MRUBY_VERSION.tar.gz" > mruby-$MRUBY_VERSION.tar.gz:
+      curl -L "https://github.com/mruby/mruby/archive/$MRUBY_VERSION.tar.gz" > mruby-$MRUBY_VERSION.tar.gz;
       tar xf mruby-$MRUBY_VERSION.tar.gz;
     fi'
   - cd mruby-$MRUBY_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,15 @@ script:
   - git clone --depth 1 "https://github.com/mruby/mruby.git"
   - cd mruby
   - ./minirake all test
+
   - cd "$TRAVIS_BUILD_DIR"
-  - curl "http://forum.mruby.org/download/source/mruby-1.2.0.tar.gz" > mruby-1.2.0.tar.gz
+  - curl -L "https://github.com/mruby/mruby/archive/1.2.0.tar.gz" > mruby-1.2.0.tar.gz
   - tar xf mruby-1.2.0.tar.gz
-  - cd mruby
+  - cd mruby-1.2.0
+  - ./minirake all test
+
+  - cd "$TRAVIS_BUILD_DIR"
+  - curl -L "https://github.com/mruby/mruby/archive/1.3.0.tar.gz" > mruby-1.3.0.tar.gz
+  - tar xf mruby-1.3.0.tar.gz
+  - cd mruby-1.3.0
   - ./minirake all test

--- a/.travis_config.rb
+++ b/.travis_config.rb
@@ -1,6 +1,7 @@
 MRuby::Build.new do |conf|
   toolchain :gcc
   enable_debug
+  enable_test
 
   gem :core => 'mruby-print'
   gem :core => 'mruby-sprintf'

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -5,11 +5,89 @@ MRuby::Gem::Specification.new('mruby-uv') do |spec|
   spec.add_dependency 'mruby-time',    core: 'mruby-time'
   spec.add_dependency 'mruby-sprintf', core: 'mruby-sprintf'
 
-  is_cross = build.kind_of? MRuby::CrossBuild
+  def self.run_command(env, command)
+    fail "#{command} failed" unless system(env, command)
+  end
 
-  if (not is_cross and ENV['OS'] == 'Windows_NT') || (is_cross && spec.build.host_target && spec.build.host_target.include?("mingw32"))
+  def cross?; build.kind_of? MRuby::CrossBuild end
+
+  def self.bundle_uv
+    visualcpp = ENV['VisualStudioVersion'] || ENV['VSINSTALLDIR']
+
+    version = '1.14.1'
+    libuv_dir = "#{build_dir}/libuv-#{version}"
+    libuv_lib = libfile "#{libuv_dir}/.libs/libuv"
+    header = "#{libuv_dir}/include/uv.h"
+    objext = visualcpp ? '.obj' : '.o'
+    libmruby_a = libfile("#{build.build_dir}/lib/libmruby")
+    libuv_objs_dir = "#{libuv_dir}/libuv_objs"
+
+    task :clean do
+      FileUtils.rm_rf [libuv_dir, "#{libuv_dir}.tar.gz"]
+    end
+
+    file header do |t|
+      begin
+        FileUtils.mkdir_p build_dir
+        Dir.chdir(build_dir) do
+          _pp 'getting', "libuv-#{version}"
+          run_command({}, "curl -L -o libuv-#{version}.tar.gz https://github.com/libuv/libuv/archive/v#{version}.tar.gz")
+          _pp 'extracting', "libuv-#{version}"
+          run_command({}, "tar -zxf libuv-#{version}.tar.gz")
+        end
+      rescue => e
+        p e
+        FileUtils.rm_f "libuv-#{version}.tar.gz"
+        FileUtils.rm_rf "libuv-#{version}"
+        raise e
+      end
+    end
+
+    file libuv_lib => header do |t|
+      Dir.chdir(libuv_dir) do
+        e = {
+          'CC'  => "#{build.cc.command} #{build.cc.flags.join(' ')}",
+          'CXX' => "#{build.cxx.command} #{build.cxx.flags.join(' ')}",
+          'LD'  => "#{build.linker.command} #{build.linker.flags.join(' ')}",
+          'AR'  => build.archiver.command
+        }
+        _pp 'autotools', libuv_dir
+        configure_opts = %w(--disable-shared --enable-static)
+        if cross? && build.host_target && build.build_target
+          configure_opts += ["--host #{build.host_target}", "--build #{build.build_target}"]
+          e['LD'] = "x86_64-w64-mingw32-ld #{build.linker.flags.join(' ')}" if build.host_target == 'x86_64-w64-mingw32'
+          e['LD'] = "i686-w64-mingw32-ld #{build.linker.flags.join(' ')}" if build.host_target == 'i686-w64-mingw32'
+        end
+        run_command e, './autogen.sh' if File.exists? 'autogen.sh'
+        run_command e, "./configure #{configure_opts.join(" ")}"
+        run_command e, 'make'
+      end
+
+      FileUtils.mkdir_p libuv_objs_dir
+      Dir.chdir(libuv_objs_dir) do
+        unless visualcpp
+          `ar x #{libuv_lib}`
+        else
+          winname = libuv_lib.gsub(%'/', '\\')
+          `lib -nologo -list #{winname}`.each_line do |line|
+            line.chomp!
+            `lib -nologo -extract:#{line} #{winname}`
+          end
+        end
+      end
+      file libmruby_a => Dir.glob("#{libuv_objs_dir}/*#{objext}")
+    end
+
+    file libmruby_a => Dir.glob("#{libuv_objs_dir}/*#{objext}") if File.exists? libuv_lib
+
+    Dir.glob("#{dir}/src/*.c") { |f| file f => libuv_lib }
+    cc.include_paths << "#{libuv_dir}/include"
+    linker.library_paths << File.dirname(libuv_lib)
+  end
+
+  if (not cross? and ENV['OS'] == 'Windows_NT') || (cross? && spec.build.host_target && spec.build.host_target.include?("mingw32"))
     spec.linker.libraries << ['uv', 'psapi', 'iphlpapi', 'ws2_32']
-  elsif (not is_cross and `uname`.chomp =~ /darwin|freebsd/i) || (is_cross && spec.build.host_target && spec.build.host_target.include?("darwin"))
+  elsif (not cross? and `uname`.chomp =~ /darwin|freebsd/i) || (cross? && spec.build.host_target && spec.build.host_target.include?("darwin"))
     spec.linker.libraries << ['uv', 'pthread', 'm']
   else
     spec.linker.libraries << ['uv', 'pthread', 'rt', 'm', 'dl']
@@ -22,70 +100,5 @@ MRuby::Gem::Specification.new('mruby-uv') do |spec|
     next
   end
 
-  require 'open3'
-
-  version = '1.0.0'
-  libuv_dir = "#{build_dir}/libuv-#{version}"
-  libuv_lib = libfile "#{libuv_dir}/.libs/libuv"
-  header = "#{libuv_dir}/include/uv.h"
-
-  task :clean do
-    FileUtils.rm_rf [libuv_dir, "#{libuv_dir}.tar.gz"]
-  end
-
-  file header do |t|
-    FileUtils.mkdir_p libuv_dir
-
-    _pp 'getting', "libuv-v#{version}"
-    begin
-      FileUtils.mkdir_p build_dir
-      Dir.chdir(build_dir) do
-        File.open("libuv-v#{version}.tar.gz", 'w') do |f|
-          IO.popen("curl -L \"https://github.com/joyent/libuv/archive/v#{version}.tar.gz\"") do |io|
-            f.write io.read
-          end
-          raise IOError unless $?.exitstatus
-        end
-
-        _pp 'extracting', "libuv-v#{version}"
-        `tar -zxf libuv-v#{version}.tar.gz`
-        raise IOError unless $?.exitstatus
-      end
-    rescue IOError
-      File.delete "libuv-v#{version}.tar.gz"
-      exit(-1)
-    end
-  end
-
-  def run_command(env, command)
-    Open3.popen2e(env, command) do |stdin, stdout, thread|
-      print stdout.read
-      fail "#{command} failed" if thread.value != 0
-    end
-  end
-
-  file libuv_lib => header do |t|
-    Dir.chdir(libuv_dir) do
-      e = {
-        'CC'  => "#{spec.build.cc.command} #{spec.build.cc.flags.join(' ')}",
-        'CXX' => "#{spec.build.cxx.command} #{spec.build.cxx.flags.join(' ')}",
-        'LD'  => "#{spec.build.linker.command} #{spec.build.linker.flags.join(' ')}",
-        'AR'  => spec.build.archiver.command
-      }
-      _pp 'autotools', libuv_dir
-      configure_opts = %w(--disable-shared --enable-static)
-      if is_cross && spec.build.host_target && spec.build.build_target
-        configure_opts += ["--host #{spec.build.host_target}", "--build #{spec.build.build_target}"]
-        e['LD'] = "x86_64-w64-mingw32-ld #{spec.build.linker.flags.join(' ')}" if build.host_target == 'x86_64-w64-mingw32'
-        e['LD'] = "i686-w64-mingw32-ld #{spec.build.linker.flags.join(' ')}" if build.host_target == 'i686-w64-mingw32'
-      end
-      run_command e, './autogen.sh' if File.exists? 'autogen.sh'
-      run_command e, "./configure #{configure_opts.join(" ")}"
-      run_command e, 'make'
-    end
-  end
-
-  Dir.glob("#{dir}/src/*.c") { |f| file f => libuv_lib }
-  spec.cc.include_paths << "#{libuv_dir}/include"
-  spec.linker.library_paths << File.dirname(libuv_lib)
+  spec.bundle_uv
 end

--- a/src/fs.c
+++ b/src/fs.c
@@ -1154,6 +1154,7 @@ void mrb_mruby_uv_gem_init_fs(mrb_state *mrb, struct RClass *UV)
   mrb_define_class_method(mrb, _class_uv_fs, "chown", mrb_uv_fs_chown, MRB_ARGS_REQ(3));
   mrb_define_class_method(mrb, _class_uv_fs, "mkdtemp", mrb_uv_fs_mkdtemp, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, _class_uv_fs, "access", mrb_uv_fs_access, MRB_ARGS_REQ(2));
+  mrb_define_class_method(mrb, _class_uv_fs, "scandir", mrb_uv_fs_scandir, MRB_ARGS_REQ(2));
 
   /* for compatibility */
   mrb_define_class_method(mrb, _class_uv_fs, "readdir", mrb_uv_fs_scandir, MRB_ARGS_REQ(2));

--- a/src/handle.c
+++ b/src/handle.c
@@ -12,12 +12,6 @@ get_loop(mrb_state *mrb, mrb_value v)
   }
 }
 
-typedef struct {
-  mrb_state* mrb;
-  mrb_value instance;
-  uv_handle_t handle;
-} mrb_uv_handle;
-
 static void
 no_yield_close_cb(uv_handle_t *h)
 {
@@ -29,17 +23,17 @@ static void
 mrb_uv_handle_free(mrb_state *mrb, void *p)
 {
   mrb_uv_handle* context = (mrb_uv_handle*) p;
-  if (context) {
-    if (context->handle.type == UV_UNKNOWN_HANDLE) {
-      mrb_free(context->mrb, context);
-    }
-    else if (!uv_is_closing(&context->handle)) {
-      uv_close(&context->handle, no_yield_close_cb);
-    }
+  if (!context) { return; }
+
+  mrb_assert(context->handle.type != UV_UNKNOWN_HANDLE);
+  // mrb_assert(!uv_has_ref(&context->handle));
+
+  if (!uv_is_closing(&context->handle)) {
+    uv_close(&context->handle, no_yield_close_cb);
   }
 }
 
-static const struct mrb_data_type mrb_uv_handle_type = {
+const struct mrb_data_type mrb_uv_handle_type = {
   "uv_handle", mrb_uv_handle_free
 };
 

--- a/src/handle.c
+++ b/src/handle.c
@@ -1976,6 +1976,12 @@ mrb_mruby_uv_gem_init_handle(mrb_state *mrb, struct RClass *UV)
   mrb_define_method(mrb, _class_uv_signal, "start", mrb_uv_signal_start, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, _class_uv_signal, "stop", mrb_uv_signal_stop, MRB_ARGS_NONE());
   mrb_define_const(mrb, _class_uv_signal, "SIGINT", mrb_fixnum_value(SIGINT));
+#ifdef SIGUSR1
+  mrb_define_const(mrb, _class_uv_signal, "SIGUSR1", mrb_fixnum_value(SIGUSR1));
+#endif
+#ifdef SIGUSR2
+  mrb_define_const(mrb, _class_uv_signal, "SIGUSR2", mrb_fixnum_value(SIGUSR2));
+#endif
 #ifdef SIGPIPE
   mrb_define_const(mrb, _class_uv_signal, "SIGPIPE", mrb_fixnum_value(SIGPIPE));
 #endif

--- a/src/mrb_uv.c
+++ b/src/mrb_uv.c
@@ -22,13 +22,13 @@ mrb_uv_gc_table_clean(mrb_state *mrb, uv_loop_t *target)
 {
   int i, new_i;
   mrb_value t = mrb_uv_gc_table_get(mrb);
-  mrb_value *ary = RARRAY_PTR(t);
+  mrb_value const *ary = RARRAY_PTR(t);
   for (i = 0, new_i = 0; i < RARRAY_LEN(t); ++i) {
     mrb_value const v = ary[i];
     if (!DATA_PTR(v) ||
         (DATA_TYPE(v) == &mrb_uv_handle_type && ((mrb_uv_handle*)DATA_PTR(v))->handle.loop == target) ||
         mrb_iv_defined(mrb, ary[i], mrb_intern_lit(mrb, "close_cb"))) {
-      ary[new_i++] = ary[i];
+      mrb_ary_set(mrb, t, new_i++, ary[i]);
     }
   }
   mrb_ary_resize(mrb, t, new_i);

--- a/src/mrb_uv.c
+++ b/src/mrb_uv.c
@@ -1110,10 +1110,9 @@ mrb_mruby_uv_gem_init(mrb_state* mrb) {
   struct RClass* _class_uv_addrinfo;
   struct RClass* _class_uv_ip4addr;
   struct RClass* _class_uv_ip6addr;
-  struct RClass* _class_uv_error;
   struct RClass* _class_uv_req;
 
-  _class_uv_error = mrb_define_class(mrb, "UVError", E_NAME_ERROR);
+  mrb_define_class(mrb, "UVError", E_NAME_ERROR);
 
   _class_uv = mrb_define_module(mrb, "UV");
   mrb_define_module_function(mrb, _class_uv, "run", mrb_uv_run, MRB_ARGS_NONE());

--- a/src/mrb_uv.c
+++ b/src/mrb_uv.c
@@ -1195,6 +1195,30 @@ mrb_mruby_uv_gem_init(mrb_state* mrb) {
   mrb_define_method(mrb, _class_uv_addrinfo, "addr", mrb_uv_addrinfo_addr, MRB_ARGS_NONE());
   mrb_define_method(mrb, _class_uv_addrinfo, "canonname", mrb_uv_addrinfo_canonname, MRB_ARGS_NONE());
   mrb_define_method(mrb, _class_uv_addrinfo, "next", mrb_uv_addrinfo_next, MRB_ARGS_NONE());
+
+  mrb_define_const(mrb, _class_uv_addrinfo, "AF_INET", mrb_fixnum_value(AF_INET));
+  mrb_define_const(mrb, _class_uv_addrinfo, "AF_INET6", mrb_fixnum_value(AF_INET6));
+  mrb_define_const(mrb, _class_uv_addrinfo, "AF_UNSPEC", mrb_fixnum_value(AF_UNSPEC));
+#ifdef AF_UNIX
+  mrb_define_const(mrb, _class_uv_addrinfo, "AF_UNIX", mrb_fixnum_value(AF_UNIX));
+#endif
+
+  mrb_define_const(mrb, _class_uv_addrinfo, "SOCK_STREAM", mrb_fixnum_value(SOCK_STREAM));
+  mrb_define_const(mrb, _class_uv_addrinfo, "SOCK_DGRAM", mrb_fixnum_value(SOCK_DGRAM));
+  mrb_define_const(mrb, _class_uv_addrinfo, "SOCK_RAW", mrb_fixnum_value(SOCK_RAW));
+  mrb_define_const(mrb, _class_uv_addrinfo, "SOCK_SEQPACKET", mrb_fixnum_value(SOCK_SEQPACKET));
+
+  mrb_define_const(mrb, _class_uv_addrinfo, "AI_PASSIVE", mrb_fixnum_value(AI_PASSIVE));
+  mrb_define_const(mrb, _class_uv_addrinfo, "AI_CANONNAME", mrb_fixnum_value(AI_CANONNAME));
+  mrb_define_const(mrb, _class_uv_addrinfo, "AI_NUMERICHOST", mrb_fixnum_value(AI_NUMERICHOST));
+  mrb_define_const(mrb, _class_uv_addrinfo, "AI_NUMERICSERV", mrb_fixnum_value(AI_NUMERICSERV));
+  mrb_define_const(mrb, _class_uv_addrinfo, "AI_V4MAPPED", mrb_fixnum_value(AI_V4MAPPED));
+  mrb_define_const(mrb, _class_uv_addrinfo, "AI_ALL", mrb_fixnum_value(AI_ALL));
+  mrb_define_const(mrb, _class_uv_addrinfo, "AI_ADDRCONFIG", mrb_fixnum_value(AI_ADDRCONFIG));
+
+  mrb_define_const(mrb, _class_uv_addrinfo, "IPPROTO_TCP", mrb_fixnum_value(IPPROTO_TCP));
+  mrb_define_const(mrb, _class_uv_addrinfo, "IPPROTO_UDP", mrb_fixnum_value(IPPROTO_UDP));
+
   mrb_gc_arena_restore(mrb, ai);
 
   _class_uv_ip4addr = mrb_define_class_under(mrb, _class_uv, "Ip4Addr", mrb->object_class);

--- a/src/mrb_uv.c
+++ b/src/mrb_uv.c
@@ -547,27 +547,27 @@ mrb_uv_getaddrinfo(mrb_state *mrb, mrb_value self)
   }
 
   // parse hints
-  value = mrb_hash_get(mrb, mrb_hints, mrb_symbol_value(mrb_intern_cstr(mrb, "ai_family")));
-  if (mrb_obj_equal(mrb, value, mrb_symbol_value(mrb_intern_cstr(mrb, "ipv4")))) {
+  value = mrb_hash_get(mrb, mrb_hints, mrb_symbol_value(mrb_intern_lit(mrb, "ai_family")));
+  if (mrb_obj_equal(mrb, value, mrb_symbol_value(mrb_intern_lit(mrb, "ipv4")))) {
     hints.ai_family = AF_INET;
-  } else if (mrb_obj_equal(mrb, value, mrb_symbol_value(mrb_intern_cstr(mrb, "ipv6")))) {
+  } else if (mrb_obj_equal(mrb, value, mrb_symbol_value(mrb_intern_lit(mrb, "ipv6")))) {
     hints.ai_family = AF_INET6;
   }
-  value = mrb_hash_get(mrb, mrb_hints, mrb_symbol_value(mrb_intern_cstr(mrb, "datagram")));
-  if (mrb_obj_equal(mrb, value, mrb_symbol_value(mrb_intern_cstr(mrb, "dgram")))) {
+  value = mrb_hash_get(mrb, mrb_hints, mrb_symbol_value(mrb_intern_lit(mrb, "datagram")));
+  if (mrb_obj_equal(mrb, value, mrb_symbol_value(mrb_intern_lit(mrb, "dgram")))) {
     hints.ai_socktype = SOCK_DGRAM;
-  } else if (mrb_obj_equal(mrb, value, mrb_symbol_value(mrb_intern_cstr(mrb, "stream")))) {
+  } else if (mrb_obj_equal(mrb, value, mrb_symbol_value(mrb_intern_lit(mrb, "stream")))) {
     hints.ai_socktype = SOCK_STREAM;
   }
-  value = mrb_hash_get(mrb, mrb_hints, mrb_symbol_value(mrb_intern_cstr(mrb, "protocol")));
-  if (mrb_obj_equal(mrb, value, mrb_symbol_value(mrb_intern_cstr(mrb, "ip")))) {
+  value = mrb_hash_get(mrb, mrb_hints, mrb_symbol_value(mrb_intern_lit(mrb, "protocol")));
+  if (mrb_obj_equal(mrb, value, mrb_symbol_value(mrb_intern_lit(mrb, "ip")))) {
     hints.ai_protocol = IPPROTO_IP;
-  } else if (mrb_obj_equal(mrb, value, mrb_symbol_value(mrb_intern_cstr(mrb, "udp")))) {
+  } else if (mrb_obj_equal(mrb, value, mrb_symbol_value(mrb_intern_lit(mrb, "udp")))) {
     hints.ai_protocol = IPPROTO_UDP;
-  } else if (mrb_obj_equal(mrb, value, mrb_symbol_value(mrb_intern_cstr(mrb, "tcp")))) {
+  } else if (mrb_obj_equal(mrb, value, mrb_symbol_value(mrb_intern_lit(mrb, "tcp")))) {
     hints.ai_protocol = IPPROTO_TCP;
   }
-  value = mrb_hash_get(mrb, mrb_hints, mrb_symbol_value(mrb_intern_cstr(mrb, "flags")));
+  value = mrb_hash_get(mrb, mrb_hints, mrb_symbol_value(mrb_intern_lit(mrb, "flags")));
   if (mrb_obj_is_kind_of(mrb, value, mrb->fixnum_class)) {
     hints.ai_flags = mrb_int(mrb, value);
   }

--- a/src/mrb_uv.c
+++ b/src/mrb_uv.c
@@ -1,3 +1,4 @@
+#define _WIN32_WINNT 0x0600
 #include "mruby/uv.h"
 #include "mrb_uv.h"
 

--- a/src/mrb_uv.c
+++ b/src/mrb_uv.c
@@ -533,12 +533,12 @@ mrb_uv_getaddrinfo(mrb_state *mrb, mrb_value self)
   mrb_value node, service, b = mrb_nil_value(), req_val;
   mrb_value mrb_hints = mrb_hash_new(mrb);
   mrb_uv_req_t* req;
+  mrb_value value;
   struct addrinfo hints = {0};
   hints.ai_family = AF_UNSPEC;
   hints.ai_socktype = 0;
   hints.ai_protocol = 0;
   hints.ai_flags = 0;
-  mrb_value value;
 
   mrb_get_args(mrb, "SS|H&", &node, &service, &mrb_hints, &b);
 

--- a/src/mrb_uv.h
+++ b/src/mrb_uv.h
@@ -63,7 +63,7 @@ void* mrb_uv_get_ptr(mrb_state*, mrb_value, struct mrb_data_type const*);
 uv_file mrb_uv_to_fd(mrb_state *mrb, mrb_value v);
 
 mrb_value mrb_uv_gc_table_get(mrb_state *mrb);
-void mrb_uv_gc_table_clean(mrb_state *mrb);
+void mrb_uv_gc_table_clean(mrb_state *mrb, uv_loop_t *l);
 void mrb_uv_gc_protect(mrb_state *mrb, mrb_value v);
 
 mrb_value mrb_uv_req_alloc(mrb_state *mrb, uv_req_type t, mrb_value proc);
@@ -74,6 +74,14 @@ typedef struct mrb_uv_req_t {
   mrb_value instance, block;
   uv_req_t req;
 } mrb_uv_req_t;
+
+typedef struct {
+  mrb_state* mrb;
+  mrb_value instance;
+  uv_handle_t handle;
+} mrb_uv_handle;
+
+extern const struct mrb_data_type mrb_uv_handle_type;
 
 uv_os_sock_t mrb_uv_to_socket(mrb_state *mrb, mrb_value v);
 

--- a/test/callback.rb
+++ b/test/callback.rb
@@ -205,17 +205,17 @@ assert 'UV::Loop' do
 end
 
 assert_uv 'UV::Signal' do
-  skip if UV::IS_WINDOWS
+  skip if UV::IS_WINDOWS || !UV::Signal.const_defined?(:SIGUSR1)
 
   s = UV::Signal.new
-  s.start UV::Signal::SIGWINCH do |x|
-    assert_equal UV::Signal::SIGWINCH, x
+  s.start UV::Signal::SIGUSR1 do |x|
+    assert_equal UV::Signal::SIGUSR1, x
     s.close
   end
 
   t = UV::Timer.new
   t.start UV_INTERVAL, 0 do
-    raise_signal UV::Signal::SIGWINCH
+    raise_signal UV::Signal::SIGUSR1
     t.close
   end
 end

--- a/test/callback.rb
+++ b/test/callback.rb
@@ -11,7 +11,6 @@ def assert_uv(name, &block)
   assert name do
     block.call
     UV.run
-    UV.default_loop.close
     UV.gc
     true
   end
@@ -348,7 +347,6 @@ assert_uv 'UV::TCP IPv6 server/client' do
   end
 end
 
-=begin
 assert_uv 'UV::TCP IPv4 server/client' do
   test_str = "helloworld\r\n"
 
@@ -376,7 +374,6 @@ assert_uv 'UV::TCP IPv4 server/client' do
     s.close
   end
 end
-=end
 
 =begin
 assert_uv 'UV::FS::Event rename' do

--- a/test/callback.rb
+++ b/test/callback.rb
@@ -136,7 +136,7 @@ assert_uv 'UV::Stat' do
 end
 
 assert_uv 'UV.getaddrinfo' do
-  req = UV.getaddrinfo('www.google.com', 'http') { |x, a|
+  req = UV.getaddrinfo('localhost', 'http') { |x, a|
     next unless a
 
     assert_equal 80, a.addr.sin_port

--- a/test/callback.rb
+++ b/test/callback.rb
@@ -4,6 +4,7 @@ def remove_uv_test_tmpfile
   UV::FS.unlink(UV::IS_WINDOWS ? '\\\\.\\pipe\\mruby-uv' : '/tmp/mruby-uv') rescue nil
   UV::FS.unlink 'foo-bar/bar.txt' rescue nil
   UV::FS.unlink 'foo-bar/foo.txt' rescue nil
+  UV::FS.rmdir 'foo-bar/dir' rescue nil
   UV::FS.rmdir 'foo-bar' rescue nil
 end
 
@@ -54,7 +55,7 @@ assert_uv 'UV::FS' do
   remove_uv_test_tmpfile
 end
 
-assert_uv 'UV::FS.readdir' do
+assert_uv 'UV::FS.scandir' do
   remove_uv_test_tmpfile
 
   test_str = 'helloworld'
@@ -68,16 +69,20 @@ assert_uv 'UV::FS.readdir' do
   f.write(test_str)
   f.close
 
+  UV::FS.mkdir 'foo-bar/dir'
+
+  res = [['bar.txt', :file], ['dir', :dir], ['foo.txt', :file]]
+
   # async version
-  UV::FS.readdir 'foo-bar', 0 do |a|
-    assert_equal [['bar.txt', :file], ['foo.txt', :file]], a.sort
+  UV::FS.scandir 'foo-bar', 0 do |a|
+    assert_equal res, a.sort
 
     remove_uv_test_tmpfile
   end
 
   # sync version
-  a = UV::FS.readdir 'foo-bar', 0
-  assert_equal [['bar.txt', :file], ['foo.txt', :file]], a.sort
+  a = UV::FS.scandir 'foo-bar', 0
+  assert_equal res, a.sort
 end
 
 assert_uv 'UV::FS.symlink' do

--- a/test/callback.rb
+++ b/test/callback.rb
@@ -73,16 +73,20 @@ assert_uv 'UV::FS.scandir' do
 
   res = [['bar.txt', :file], ['dir', :dir], ['foo.txt', :file]]
 
+  # sync version
+  a = UV::FS.scandir 'foo-bar', 0
+  if a[0][1] == :unknown
+    remove_uv_test_tmpfile
+    skip
+  end
+  assert_equal res, a.sort
+
   # async version
-  UV::FS.scandir 'foo-bar', 0 do |a|
-    assert_equal res, a.sort
+  UV::FS.scandir 'foo-bar', 0 do |d|
+    assert_equal res, d.sort
 
     remove_uv_test_tmpfile
   end
-
-  # sync version
-  a = UV::FS.scandir 'foo-bar', 0
-  assert_equal res, a.sort
 end
 
 assert_uv 'UV::FS.symlink' do

--- a/test/uv.rb
+++ b/test/uv.rb
@@ -177,3 +177,10 @@ assert 'UV.get_error' do
   assert_equal :EPERM, err.name
   assert_equal 'operation not permitted', err.message
 end
+
+assert 'UV::Addrinfo constants' do
+  assert_true UV::Addrinfo.const_defined? :AF_INET
+  assert_true UV::Addrinfo.const_defined? :SOCK_STREAM
+  assert_true UV::Addrinfo.const_defined? :AI_PASSIVE
+  assert_true UV::Addrinfo.const_defined? :IPPROTO_TCP
+end

--- a/test/uv.rb
+++ b/test/uv.rb
@@ -1,4 +1,5 @@
 assert('UV.guess_handle') do
+  skip if UV.guess_handle(0) == :pipe
   assert_equal :tty, UV.guess_handle(0)
   assert_equal :tty, UV.guess_handle(1)
   assert_equal :tty, UV.guess_handle(2)

--- a/test/uv.rb
+++ b/test/uv.rb
@@ -159,6 +159,18 @@ assert 'UV.getaddrinfo ipv6' do
   UV::run()
 end
 
+assert 'UV.getaddrinfo.next' do
+  UV::getaddrinfo('localhost', 'http') do |x, info|
+    while info
+      assert_kind_of UV::Addrinfo, info
+      info = info.next
+    end
+
+    assert_nil info
+  end
+  UV::run()
+end
+
 assert 'UV.get_error' do
   err = UV::get_error(-1)
   assert_true err.is_a?(UVError)

--- a/test/uv.rb
+++ b/test/uv.rb
@@ -145,24 +145,17 @@ assert 'UV.thread_self' do
 end
 
 assert 'UV.getaddrinfo ipv4' do
-  UV::getaddrinfo('google.com', 'http', {:ai_family => :ipv4}) do |x, info|
-    assert_true(info.addr.is_a?(UV::Ip4Addr), "Expected UV::Ip4Addr but got #{info.addr.class}")
+  UV::getaddrinfo('localhost', 'http', {:ai_family => :ipv4}) do |x, info|
+    assert_kind_of UV::Ip4Addr, info.addr
   end
   UV::run()
 end
 
 assert 'UV.getaddrinfo ipv6' do
-  UV::getaddrinfo('google.com', 'http', {:ai_family => :ipv6}) do |x, info|
-    assert_true(info.addr.is_a?(UV::Ip6Addr), "Expected UV::Ip4Addr but got #{info.addr.class}")
+  UV::getaddrinfo('localhost', 'http', {:ai_family => :ipv6}) do |x, info|
+    assert_kind_of UV::Ip6Addr, info.addr
   end
   UV::run()
-end
-
-assert 'UV.getaddrinfo' do
-  req = UV::getaddrinfo('google.com', 'http') {}
-  UV::run()
-
-  assert_true req.is_a?(UV::Req)
 end
 
 assert 'UV.get_error' do


### PR DESCRIPTION
* Fixing old bugs that was kept unfixed.
* Fixes travis.(Also tests 1.2, 1.3, master)
* Skips `scandir` when file system always return file type `unknown`.
* Add `UV::FS.scandir` which make `UV::FS.readdir` an alias.