### PR TITLE
Add supports for APIs after 1.0.0.

### DIFF
--- a/src/fs.c
+++ b/src/fs.c
@@ -162,6 +162,7 @@ _uv_fs_cb(uv_fs_t* req)
     }
     break;
 
+  case UV_FS_REALPATH:
   case UV_FS_READLINK: {
     mrb_value res;
     mrb_assert(!mrb_nil_p(proc));
@@ -964,6 +965,41 @@ mrb_uv_fs_readlink(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_value
+mrb_uv_fs_realpath(mrb_state *mrb, mrb_value self)
+{
+  char *path;
+  mrb_value b;
+  static mrb_uv_file ctx;
+  uv_fs_t *req;
+  int err;
+
+  mrb_get_args(mrb, "&z", &b, &path);
+
+  if (!mrb_nil_p(b)) {
+    mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "fs_cb"), b);
+    ctx.mrb = mrb;
+    ctx.instance = self;
+    ctx.fd = -1;
+  }
+
+  req = (uv_fs_t*)mrb_malloc(mrb, sizeof(uv_fs_t));
+  req->data = &ctx;
+  err = uv_fs_realpath(uv_default_loop(), req, path, mrb_nil_p(b)? NULL : _uv_fs_cb);
+  if (err < 0) {
+    mrb_free(mrb, req);
+    mrb_uv_check_error(mrb, err);
+  }
+
+  if (mrb_nil_p(b)) {
+    mrb_value const ret = mrb_str_new_cstr(mrb, req->ptr);
+    uv_fs_req_cleanup(req);
+    mrb_free(mrb, req);
+    return ret;
+  }
+  return self;
+}
+
+static mrb_value
 mrb_uv_fs_chown(mrb_state *mrb, mrb_value self)
 {
   char *path;
@@ -1098,6 +1134,26 @@ mrb_uv_fs_access(mrb_state *mrb, mrb_value self)
   }
 }
 
+static mrb_value
+mrb_uv_fs_copyfile(mrb_state *mrb, mrb_value self)
+{
+  const char *old_path, *new_path;
+  mrb_int flags;
+  mrb_value proc;
+
+  mrb_get_args(mrb, "&zzi", &proc, &old_path, &new_path, &flags);
+  if (mrb_nil_p(proc)) {
+    uv_fs_t req;
+    mrb_uv_check_error(mrb, uv_fs_copyfile(uv_default_loop(), &req, old_path, new_path, flags, NULL));
+    return mrb_nil_value();
+  } else {
+    mrb_value req_val = mrb_uv_req_alloc(mrb, UV_FS, proc);
+    mrb_uv_req_t *req = (mrb_uv_req_t*)DATA_PTR(req_val);
+    mrb_uv_check_error(mrb, uv_fs_copyfile(uv_default_loop(), (uv_fs_t*)&req->req, old_path, new_path, flags, fs_req_cb));
+    return req_val;
+  }
+}
+
 void mrb_mruby_uv_gem_init_fs(mrb_state *mrb, struct RClass *UV)
 {
   struct RClass *_class_uv_fs;
@@ -1126,6 +1182,7 @@ void mrb_mruby_uv_gem_init_fs(mrb_state *mrb, struct RClass *UV)
   mrb_define_const(mrb, _class_uv_fs, "R_OK", mrb_fixnum_value(R_OK));
   mrb_define_const(mrb, _class_uv_fs, "W_OK", mrb_fixnum_value(W_OK));
   mrb_define_const(mrb, _class_uv_fs, "X_OK", mrb_fixnum_value(X_OK));
+  mrb_define_const(mrb, _class_uv_fs, "COPYFILE_EXCL", mrb_fixnum_value(UV_FS_COPYFILE_EXCL));
   mrb_define_method(mrb, _class_uv_fs, "write", mrb_uv_fs_write, MRB_ARGS_REQ(1) | MRB_ARGS_OPT(2));
   mrb_define_method(mrb, _class_uv_fs, "read", mrb_uv_fs_read, MRB_ARGS_REQ(0) | MRB_ARGS_OPT(2));
   mrb_define_method(mrb, _class_uv_fs, "datasync", mrb_uv_fs_fdatasync, MRB_ARGS_NONE());
@@ -1155,6 +1212,8 @@ void mrb_mruby_uv_gem_init_fs(mrb_state *mrb, struct RClass *UV)
   mrb_define_class_method(mrb, _class_uv_fs, "mkdtemp", mrb_uv_fs_mkdtemp, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, _class_uv_fs, "access", mrb_uv_fs_access, MRB_ARGS_REQ(2));
   mrb_define_class_method(mrb, _class_uv_fs, "scandir", mrb_uv_fs_scandir, MRB_ARGS_REQ(2));
+  mrb_define_class_method(mrb, _class_uv_fs, "copyfile", mrb_uv_fs_copyfile, MRB_ARGS_REQ(2) | MRB_ARGS_OPT(1));
+  mrb_define_class_method(mrb, _class_uv_fs, "realpath", mrb_uv_fs_realpath, MRB_ARGS_REQ(1));
 
   /* for compatibility */
   mrb_define_class_method(mrb, _class_uv_fs, "readdir", mrb_uv_fs_scandir, MRB_ARGS_REQ(2));

--- a/src/handle.c
+++ b/src/handle.c
@@ -342,7 +342,7 @@ mrb_uv_pipe_getsockname(mrb_state *mrb, mrb_value self)
   }
   mrb_uv_check_error(mrb, res);
 
-  mrb_str_resize(mrb, buf, s - 1);
+  mrb_str_resize(mrb, buf, s);
   return buf;
 }
 
@@ -364,7 +364,7 @@ mrb_uv_pipe_getpeername(mrb_state *mrb, mrb_value self)
   }
   mrb_uv_check_error(mrb, res);
 
-  mrb_str_resize(mrb, buf, s - 1);
+  mrb_str_resize(mrb, buf, s);
   return buf;
 }
 
@@ -1544,7 +1544,7 @@ mrb_uv_fs_poll_getpath(mrb_state *mrb, mrb_value self)
   }
   mrb_uv_check_error(mrb, res);
 
-  mrb_str_resize(mrb, buf, s - 1);
+  mrb_str_resize(mrb, buf, s);
   return buf;
 }
 

--- a/src/mrb_uv.c
+++ b/src/mrb_uv.c
@@ -1238,7 +1238,7 @@ mrb_uv_os_homedir(mrb_state *mrb, mrb_value self)
   }
   mrb_uv_check_error(mrb, res);
 
-  mrb_str_resize(mrb, buf, s - 1);
+  mrb_str_resize(mrb, buf, s);
   return buf;
 }
 
@@ -1258,7 +1258,7 @@ mrb_uv_os_tmpdir(mrb_state *mrb, mrb_value self)
   }
   mrb_uv_check_error(mrb, res);
 
-  mrb_str_resize(mrb, buf, s - 1);
+  mrb_str_resize(mrb, buf, s);
   return buf;
 }
 
@@ -1279,9 +1279,12 @@ mrb_uv_os_getenv(mrb_state *mrb, mrb_value self)
     mrb_str_resize(mrb, buf, s);
     res = uv_os_getenv(env, RSTRING_PTR(buf), &s);
   }
+
+  if (res == UV_ENOENT) { return mrb_nil_value(); }
+
   mrb_uv_check_error(mrb, res);
 
-  mrb_str_resize(mrb, buf, s - 1);
+  mrb_str_resize(mrb, buf, s);
   return buf;
 }
 
@@ -1319,7 +1322,7 @@ mrb_uv_os_gethostname(mrb_state *mrb, mrb_value self)
   }
   mrb_uv_check_error(mrb, res);
 
-  mrb_str_resize(mrb, buf, s - 1);
+  mrb_str_resize(mrb, buf, s);
   return buf;
 }
 

--- a/src/mrb_uv.c
+++ b/src/mrb_uv.c
@@ -75,6 +75,75 @@ mrb_uv_data_set(mrb_state *mrb, mrb_value self)
   return self;
 }
 
+// UV::Passwd
+static void
+mrb_uv_passwd_free(mrb_state *mrb, void *p)
+{
+  uv_passwd_t *passwd = (uv_passwd_t*)p;
+  if (!p) { return; }
+
+  uv_os_free_passwd(passwd);
+  mrb_free(mrb, p);
+}
+
+static mrb_data_type const passwd_type = { "uv_passwd", mrb_uv_passwd_free };
+
+static mrb_value
+mrb_uv_passwd_init(mrb_state *mrb, mrb_value self)
+{
+  uv_passwd_t passwd, *ptr;
+
+  mrb_get_args(mrb, "");
+
+  mrb_uv_check_error(mrb, uv_os_get_passwd(&passwd));
+  ptr = (uv_passwd_t*)mrb_malloc(mrb, sizeof(uv_passwd_t));
+  *ptr = passwd;
+  DATA_PTR(self) = ptr;
+  DATA_TYPE(self) = &passwd_type;
+
+  return self;
+}
+
+static mrb_value
+mrb_uv_passwd_username(mrb_state *mrb, mrb_value self)
+{
+  uv_passwd_t *p;
+  Data_Get_Struct(mrb, self, &passwd_type, p);
+  return mrb_str_new_cstr(mrb, p->username);
+}
+
+static mrb_value
+mrb_uv_passwd_shell(mrb_state *mrb, mrb_value self)
+{
+  uv_passwd_t *p;
+  Data_Get_Struct(mrb, self, &passwd_type, p);
+  return p->shell? mrb_str_new_cstr(mrb, p->shell) : mrb_nil_value();
+}
+
+static mrb_value
+mrb_uv_passwd_homedir(mrb_state *mrb, mrb_value self)
+{
+  uv_passwd_t *p;
+  Data_Get_Struct(mrb, self, &passwd_type, p);
+  return mrb_str_new_cstr(mrb, p->homedir);
+}
+
+static mrb_value
+mrb_uv_passwd_uid(mrb_state *mrb, mrb_value self)
+{
+  uv_passwd_t *p;
+  Data_Get_Struct(mrb, self, &passwd_type, p);
+  return mrb_fixnum_value(p->uid);
+}
+
+static mrb_value
+mrb_uv_passwd_gid(mrb_state *mrb, mrb_value self)
+{
+  uv_passwd_t *p;
+  Data_Get_Struct(mrb, self, &passwd_type, p);
+  return mrb_fixnum_value(p->gid);
+}
+
 /*
  * UV::Req
  */
@@ -273,6 +342,28 @@ mrb_uv_loadavg(mrb_state *mrb, mrb_value self)
   mrb_ary_push(mrb, ret, mrb_float_value(mrb, avg[1]));
   mrb_ary_push(mrb, ret, mrb_float_value(mrb, avg[2]));
   return ret;
+}
+
+static mrb_value
+mrb_uv_loop_configure(mrb_state *mrb, mrb_value self) {
+  mrb_value h, block_signal;
+  uv_loop_t *loop = (uv_loop_t*)mrb_uv_get_ptr(mrb, self, &mrb_uv_loop_type);
+
+  mrb_get_args(mrb, "H", &h);
+
+  if (!mrb_nil_p(block_signal = mrb_hash_get(mrb, h, mrb_symbol_value(mrb_intern_lit(mrb, "block_signal"))))) {
+    mrb_uv_check_error(mrb, uv_loop_configure(loop, UV_LOOP_BLOCK_SIGNAL, mrb_fixnum(block_signal)));
+  }
+
+  return self;
+}
+
+static mrb_value
+mrb_uv_loop_fork(mrb_state *mrb, mrb_value self)
+{
+  uv_loop_t *loop = (uv_loop_t*)mrb_uv_get_ptr(mrb, self, &mrb_uv_loop_type);
+  mrb_uv_check_error(mrb, uv_loop_fork(loop));
+  return self;
 }
 
 /*********************************************************
@@ -805,6 +896,14 @@ mrb_uv_get_error(mrb_state *mrb, mrb_value self)
 }
 
 static mrb_value
+mrb_uv_translate_sys_error(mrb_state *mrb, mrb_value self)
+{
+  mrb_int err;
+  mrb_get_args(mrb, "i", &err);
+  return mrb_fixnum_value(uv_translate_sys_error(err));
+}
+
+static mrb_value
 mrb_uv_free_memory(mrb_state *mrb, mrb_value self)
 {
   return mrb_uv_from_uint64(mrb, uv_get_free_memory());
@@ -1114,6 +1213,116 @@ mrb_uv_setup_args(mrb_state *mrb, int *argc, char **argv, mrb_bool set_global)
   return new_argv;
 }
 
+// OS
+static mrb_value
+mrb_uv_get_osfhandle(mrb_state *mrb, mrb_value self)
+{
+  mrb_int i;
+  mrb_get_args(mrb, "i", &i);
+  return mrb_cptr_value(mrb, (void*)(uintptr_t)uv_get_osfhandle(i));
+}
+
+static mrb_value
+mrb_uv_os_homedir(mrb_state *mrb, mrb_value self)
+{
+  enum { BUF_SIZE = 128 };
+  mrb_value buf = mrb_str_buf_new(mrb, BUF_SIZE);
+  int res;
+  size_t s = BUF_SIZE;
+  mrb_str_resize(mrb, buf, BUF_SIZE);
+
+  res = uv_os_homedir(RSTRING_PTR(buf), &s);
+  if (res == UV_ENOBUFS) {
+    mrb_str_resize(mrb, buf, s);
+    res = uv_os_homedir(RSTRING_PTR(buf), &s);
+  }
+  mrb_uv_check_error(mrb, res);
+
+  mrb_str_resize(mrb, buf, s - 1);
+  return buf;
+}
+
+static mrb_value
+mrb_uv_os_tmpdir(mrb_state *mrb, mrb_value self)
+{
+  enum { BUF_SIZE = 128 };
+  mrb_value buf = mrb_str_buf_new(mrb, BUF_SIZE);
+  int res;
+  size_t s = BUF_SIZE;
+  mrb_str_resize(mrb, buf, BUF_SIZE);
+
+  res = uv_os_tmpdir(RSTRING_PTR(buf), &s);
+  if (res == UV_ENOBUFS) {
+    mrb_str_resize(mrb, buf, s);
+    res = uv_os_tmpdir(RSTRING_PTR(buf), &s);
+  }
+  mrb_uv_check_error(mrb, res);
+
+  mrb_str_resize(mrb, buf, s - 1);
+  return buf;
+}
+
+static mrb_value
+mrb_uv_os_getenv(mrb_state *mrb, mrb_value self)
+{
+  enum { BUF_SIZE = 128 };
+  mrb_value buf = mrb_str_buf_new(mrb, BUF_SIZE);
+  int res;
+  size_t s = BUF_SIZE;
+  char const *env;
+  mrb_get_args(mrb, "z", &env);
+
+  mrb_str_resize(mrb, buf, BUF_SIZE);
+
+  res = uv_os_getenv(env, RSTRING_PTR(buf), &s);
+  if (res == UV_ENOBUFS) {
+    mrb_str_resize(mrb, buf, s);
+    res = uv_os_getenv(env, RSTRING_PTR(buf), &s);
+  }
+  mrb_uv_check_error(mrb, res);
+
+  mrb_str_resize(mrb, buf, s - 1);
+  return buf;
+}
+
+static mrb_value
+mrb_uv_os_setenv(mrb_state *mrb, mrb_value self)
+{
+  char *env, *val;
+  mrb_get_args(mrb, "zz", &env, &val);
+  mrb_uv_check_error(mrb, uv_os_setenv(env, val));
+  return self;
+}
+
+static mrb_value
+mrb_uv_os_unsetenv(mrb_state *mrb, mrb_value self)
+{
+  char *env;
+  mrb_get_args(mrb, "z", &env);
+  mrb_uv_check_error(mrb, uv_os_unsetenv(env));
+  return self;
+}
+
+static mrb_value
+mrb_uv_os_gethostname(mrb_state *mrb, mrb_value self)
+{
+  enum { BUF_SIZE = 128 };
+  mrb_value buf = mrb_str_buf_new(mrb, BUF_SIZE);
+  int res;
+  size_t s = BUF_SIZE;
+  mrb_str_resize(mrb, buf, BUF_SIZE);
+
+  res = uv_os_gethostname(RSTRING_PTR(buf), &s);
+  if (res == UV_ENOBUFS) {
+    mrb_str_resize(mrb, buf, s);
+    res = uv_os_gethostname(RSTRING_PTR(buf), &s);
+  }
+  mrb_uv_check_error(mrb, res);
+
+  mrb_str_resize(mrb, buf, s - 1);
+  return buf;
+}
+
 /*********************************************************
  * register
  *********************************************************/
@@ -1128,6 +1337,8 @@ mrb_mruby_uv_gem_init(mrb_state* mrb) {
   struct RClass* _class_uv_ip4addr;
   struct RClass* _class_uv_ip6addr;
   struct RClass* _class_uv_req;
+  struct RClass* _class_uv_os;
+  struct RClass* _class_uv_passwd;
 
   mrb_define_class(mrb, "UVError", E_NAME_ERROR);
 
@@ -1160,6 +1371,8 @@ mrb_mruby_uv_gem_init(mrb_state* mrb) {
   mrb_define_module_function(mrb, _class_uv, "resident_set_memory", mrb_uv_resident_set_memory, MRB_ARGS_NONE());
   mrb_define_module_function(mrb, _class_uv, "uptime", mrb_uv_uptime, MRB_ARGS_NONE());
   mrb_define_module_function(mrb, _class_uv, "get_error", mrb_uv_get_error, MRB_ARGS_REQ(1));
+  mrb_define_module_function(mrb, _class_uv, "translate_sys_error", mrb_uv_translate_sys_error, MRB_ARGS_REQ(1));
+  mrb_define_module_function(mrb, _class_uv, "osfhandle", mrb_uv_get_osfhandle, MRB_ARGS_REQ(1));
 
   mrb_define_const(mrb, _class_uv, "UV_RUN_DEFAULT", mrb_fixnum_value(UV_RUN_DEFAULT));
   mrb_define_const(mrb, _class_uv, "UV_RUN_ONCE", mrb_fixnum_value(UV_RUN_ONCE));
@@ -1186,6 +1399,8 @@ mrb_mruby_uv_gem_init(mrb_state* mrb) {
   mrb_define_method(mrb, _class_uv_loop, "backend_fd", mrb_uv_backend_fd, MRB_ARGS_NONE());
   mrb_define_method(mrb, _class_uv_loop, "backend_timeout", mrb_uv_backend_timeout, MRB_ARGS_NONE());
   mrb_define_method(mrb, _class_uv_loop, "now", mrb_uv_now, MRB_ARGS_NONE());
+  mrb_define_method(mrb, _class_uv_loop, "fork", mrb_uv_loop_fork, MRB_ARGS_NONE());
+  mrb_define_method(mrb, _class_uv_loop, "configure", mrb_uv_loop_configure, MRB_ARGS_REQ(1));
   mrb_gc_arena_restore(mrb, ai);
 
   _class_uv_addrinfo = mrb_define_class_under(mrb, _class_uv, "Addrinfo", mrb->object_class);
@@ -1242,6 +1457,7 @@ mrb_mruby_uv_gem_init(mrb_state* mrb) {
   /* TODO
   uv_inet_ntop
   uv_inet_pton
+  uv_replace_allocator
   */
 
   _class_uv_req = mrb_define_class_under(mrb, _class_uv, "Req", mrb->object_class);
@@ -1249,6 +1465,23 @@ mrb_mruby_uv_gem_init(mrb_state* mrb) {
   mrb_define_method(mrb, _class_uv_req, "cancel", mrb_uv_cancel, MRB_ARGS_NONE());
   mrb_define_method(mrb, _class_uv_req, "type", mrb_uv_req_type, MRB_ARGS_NONE());
   mrb_undef_class_method(mrb, _class_uv_req, "new");
+
+  _class_uv_os = mrb_define_module_under(mrb, _class_uv, "OS");
+  mrb_define_module_function(mrb, _class_uv_os, "homedir", mrb_uv_os_homedir, MRB_ARGS_NONE());
+  mrb_define_module_function(mrb, _class_uv_os, "tmpdir", mrb_uv_os_tmpdir, MRB_ARGS_NONE());
+  mrb_define_module_function(mrb, _class_uv_os, "getenv", mrb_uv_os_getenv, MRB_ARGS_REQ(1));
+  mrb_define_module_function(mrb, _class_uv_os, "setenv", mrb_uv_os_setenv, MRB_ARGS_REQ(2));
+  mrb_define_module_function(mrb, _class_uv_os, "unsetenv", mrb_uv_os_unsetenv, MRB_ARGS_REQ(1));
+  mrb_define_module_function(mrb, _class_uv_os, "hostname", mrb_uv_os_gethostname, MRB_ARGS_NONE());
+
+  _class_uv_passwd = mrb_define_class_under(mrb, _class_uv_os, "Passwd", mrb->object_class);
+  MRB_SET_INSTANCE_TT(_class_uv_passwd, MRB_TT_DATA);
+  mrb_define_method(mrb, _class_uv_passwd, "initialize", mrb_uv_passwd_init, MRB_ARGS_NONE());
+  mrb_define_method(mrb, _class_uv_passwd, "username", mrb_uv_passwd_username, MRB_ARGS_NONE());
+  mrb_define_method(mrb, _class_uv_passwd, "shell", mrb_uv_passwd_shell, MRB_ARGS_NONE());
+  mrb_define_method(mrb, _class_uv_passwd, "homedir", mrb_uv_passwd_homedir, MRB_ARGS_NONE());
+  mrb_define_method(mrb, _class_uv_passwd, "uid", mrb_uv_passwd_uid, MRB_ARGS_NONE());
+  mrb_define_method(mrb, _class_uv_passwd, "gid", mrb_uv_passwd_gid, MRB_ARGS_NONE());
 
   mrb_mruby_uv_gem_init_fs(mrb, _class_uv);
   mrb_mruby_uv_gem_init_handle(mrb, _class_uv);

--- a/src/mrb_uv.c
+++ b/src/mrb_uv.c
@@ -1047,6 +1047,7 @@ mrb_uv_queue_work(mrb_state *mrb, mrb_value self)
   mrb_iv_set(mrb, req->instance, mrb_intern_lit(mrb, "cfunc_cb"), cfunc);
   mrb_uv_check_error(mrb, uv_queue_work(
       uv_default_loop(), (uv_work_t*)&req->req, mrb_uv_work_cb, mrb_uv_after_work_cb));
+  mrb_uv_gc_protect(mrb, req_val);
   return req_val;
 }
 

--- a/test/uv.rb
+++ b/test/uv.rb
@@ -136,6 +136,11 @@ assert 'UV::Loop#now' do
   assert_kind_of Numeric, UV.default_loop.now
 end
 
+assert 'UV::Loop#configure' do
+  skip unless UV::Signal.const_defined? :SIGPROF
+  UV.default_loop.configure block_signal: UV::Signal::SIGPROF
+end
+
 assert 'UV::SOMAXCONN' do
   assert_kind_of Fixnum, UV::SOMAXCONN
 end
@@ -183,4 +188,28 @@ assert 'UV::Addrinfo constants' do
   assert_true UV::Addrinfo.const_defined? :SOCK_STREAM
   assert_true UV::Addrinfo.const_defined? :AI_PASSIVE
   assert_true UV::Addrinfo.const_defined? :IPPROTO_TCP
+end
+
+assert 'UV::OS' do
+  assert_kind_of String, UV::OS.homedir
+  assert_kind_of String, UV::OS.tmpdir
+
+  assert_kind_of String, UV::OS.getenv('HOME')
+  assert_nil UV::OS.getenv('__gdsgdsgjsngjddsg')
+
+  UV::OS.setenv "aaaaaaa", "bbb"
+  assert_equal "bbb", UV::OS.getenv("aaaaaaa")
+  UV::OS.unsetenv "aaaaaaa"
+  assert_nil UV::OS.getenv "aaaaaaa"
+
+  assert_kind_of String, UV::OS.hostname
+end
+
+assert 'UV::OS::Passwd' do
+  p = UV::OS::Passwd.new
+  assert_kind_of String, p.username
+  p.shell
+  assert_kind_of String, p.homedir
+  assert_kind_of Fixnum, p.uid
+  assert_kind_of Fixnum, p.gid
 end


### PR DESCRIPTION
`uv_os_*` APIs are helpful for implementing standard libraries.