### PR TITLE
Updates!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 addons:
   apt:
     packages:
@@ -12,6 +12,12 @@ env:
     - MRUBY_VERSION=1.2.0
     - MRUBY_VERSION=1.3.0
     - MRUBY_VERSION=1.4.0
+before_script:
+  # Add an IPv6 config - see the corresponding Travis issue
+  # https://github.com/travis-ci/travis-ci/issues/8361
+  - if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
+      sudo sh -c 'echo 0 > /proc/sys/net/ipv6/conf/all/disable_ipv6';
+    fi
 script:
   - export MRUBY_CONFIG="$TRAVIS_BUILD_DIR/.travis_config.rb"
   - 'if [ "$MRUBY_VERSION" = "master" ] ; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     - MRUBY_VERSION=master
     - MRUBY_VERSION=1.2.0
     - MRUBY_VERSION=1.3.0
+    - MRUBY_VERSION=1.4.0
 script:
   - export MRUBY_CONFIG="$TRAVIS_BUILD_DIR/.travis_config.rb"
   - 'if [ "$MRUBY_VERSION" = "master" ] ; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ script:
       tar xf mruby-$MRUBY_VERSION.tar.gz;
     fi'
   - cd mruby-$MRUBY_VERSION
-  - ./minirake all test
+  - ./minirake -v all test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 sudo: required
-addons:
-  apt:
-    packages:
-      - gperf
 compiler:
   - gcc
   - clang

--- a/example/pipe-client-win.rb
+++ b/example/pipe-client-win.rb
@@ -1,7 +1,7 @@
 #!mruby
 begin; require 'mruby-uv'; rescue Exception; end
 
-c = UV::Pipe.new(0)
+c = UV::Pipe.new(false)
 c.connect('\\\\.\\pipe\\mruby-uv') {|x|
   if x == 0
     c.read_start {|b|

--- a/example/pipe-client.rb
+++ b/example/pipe-client.rb
@@ -1,7 +1,7 @@
 #!mruby
 begin; require 'mruby-uv'; rescue Exception; end
 
-c = UV::Pipe.new(1)
+c = UV::Pipe.new(true)
 c.connect('/tmp/mrub-yuv') {|x|
   if x == 0
     c.read_start {|b|

--- a/example/pipe-server-win.rb
+++ b/example/pipe-server-win.rb
@@ -1,7 +1,7 @@
 #!mruby
 begin; require 'mruby-uv'; rescue Exception; end
 
-s = UV::Pipe.new(0)
+s = UV::Pipe.new(false)
 s.bind('\\\\.\\pipe\\mruby-uv')
 s.listen(1) {|x|
   return if x != 0

--- a/example/pipe-server.rb
+++ b/example/pipe-server.rb
@@ -1,7 +1,7 @@
 #!mruby
 begin; require 'mruby-uv'; rescue Exception; end
 
-s = UV::Pipe.new(1)
+s = UV::Pipe.new(true)
 s.bind('/tmp/mruby-uv')
 s.listen(5) {|x|
   return if x != 0

--- a/example/process.rb
+++ b/example/process.rb
@@ -12,7 +12,7 @@ else
     'args' => ['../..']
   })
 end
-ps.stdout_pipe = UV::Pipe.new(0)
+ps.stdout_pipe = UV::Pipe.new false
 
 ps.spawn do |sig|
   puts "exit #{sig}"

--- a/include/mruby/uv.h
+++ b/include/mruby/uv.h
@@ -11,8 +11,11 @@ mrb_value mrb_uv_dlopen(mrb_state *mrb, char const *name);
 void* mrb_uv_dlsym(mrb_state *mrb, mrb_value dl, char const *name);
 void mrb_uv_dlclose(mrb_state *mrb, mrb_value dl);
 
+typedef struct mrb_uv_req_t mrb_uv_req_t;
+
 #define E_UV_ERROR mrb_class_get(mrb, "UVError")
 void mrb_uv_check_error(mrb_state*, int);
+void mrb_uv_req_check_error(mrb_state*, mrb_uv_req_t*, int);
 
 char** mrb_uv_setup_args(mrb_state *mrb, int *argc, char **argv, mrb_bool set_global);
 

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -4,6 +4,7 @@ MRuby::Gem::Specification.new('mruby-uv') do |spec|
   spec.summary = 'libuv mruby binding'
   spec.add_dependency 'mruby-time',    core: 'mruby-time'
   spec.add_dependency 'mruby-sprintf', core: 'mruby-sprintf'
+  spec.add_dependency 'mruby-fiber',   core: 'mruby-fiber'
 
   def self.run_command(env, command)
     fail "#{command} failed" unless system(env, command)

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -14,7 +14,7 @@ MRuby::Gem::Specification.new('mruby-uv') do |spec|
   def self.bundle_uv
     visualcpp = ENV['VisualStudioVersion'] || ENV['VSINSTALLDIR']
 
-    version = '1.14.1'
+    version = '1.19.1'
     libuv_dir = "#{build_dir}/libuv-#{version}"
     libuv_lib = libfile "#{libuv_dir}/.libs/libuv"
     header = "#{libuv_dir}/include/uv.h"

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -46,7 +46,7 @@ MRuby::Gem::Specification.new('mruby-uv') do |spec|
     file libuv_lib => header do |t|
       Dir.chdir(libuv_dir) do
         e = {
-          'CC'  => "#{build.cc.command} #{build.cc.flags.join(' ')}",
+          'CC'  => "#{build.cc.command} #{build.cc.flags.join(' ')} -DNDEBUG",
           'CXX' => "#{build.cxx.command} #{build.cxx.flags.join(' ')}",
           'LD'  => "#{build.linker.command} #{build.linker.flags.join(' ')}",
           'AR'  => build.archiver.command

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -2,9 +2,10 @@ MRuby::Gem::Specification.new('mruby-uv') do |spec|
   spec.license = 'MIT'
   spec.authors = 'mattn'
   spec.summary = 'libuv mruby binding'
-  spec.add_dependency 'mruby-time',    core: 'mruby-time'
-  spec.add_dependency 'mruby-sprintf', core: 'mruby-sprintf'
-  spec.add_dependency 'mruby-fiber',   core: 'mruby-fiber'
+  spec.add_dependency 'mruby-time',       core: 'mruby-time'
+  spec.add_dependency 'mruby-sprintf',    core: 'mruby-sprintf'
+  spec.add_dependency 'mruby-fiber',      core: 'mruby-fiber'
+  spec.add_dependency 'mruby-string-ext', core: 'mruby-string-ext'
 
   def self.run_command(env, command)
     fail "#{command} failed" unless system(env, command)

--- a/mrblib/thread.rb
+++ b/mrblib/thread.rb
@@ -2,4 +2,8 @@ module UV
   class Thread
     def != other; !(self == other) end
   end
+
+  class Loop
+    def != other; !(self == other) end
+  end
 end

--- a/mrblib/yarn.rb
+++ b/mrblib/yarn.rb
@@ -19,7 +19,8 @@ module UV
       @current_yarn = y
     end
 
-    def clear_current_yarn
+    def clear_current_yarn(y)
+      raise 'cannot clear yarn' if y != @current_yarn
       @current_yarn = nil
     end
   end
@@ -88,7 +89,7 @@ module UV
       @error = e
 
     ensure
-      @loop.clear_current_yarn
+      @loop.clear_current_yarn self
       prev_loop.make_current if prev_loop
     end
   end

--- a/mrblib/yarn.rb
+++ b/mrblib/yarn.rb
@@ -99,7 +99,7 @@ module UV
       *ret = @fiber.resume(*args)
 
       if @fiber.alive?
-        raise "invalid yield" unless ALIVE_CLASSES.any?{|v| ret.first.kind_of? v }
+        raise "invalid yield #{ret.inspect}" unless ALIVE_CLASSES.any?{|v| ret.first.kind_of? v }
       else
         @fiber = nil
         @result = ret

--- a/mrblib/yarn.rb
+++ b/mrblib/yarn.rb
@@ -35,7 +35,7 @@ module UV
       @loop = loop
     end
 
-    attr_reader :loop, :error
+    attr_reader :loop, :error, :req
 
     def ended?; @fiber.nil? end
     def result
@@ -76,12 +76,12 @@ module UV
       ps.spawn do |x, sig|
         str = ''
         out.read_start do |b|
-          if b == :eof
-            y.resume(str)
-            out.close
-          else
+          if b.kind_of? String
             str.concat b
+            next
           end
+          y.resume(str)
+          out.close
         end
       end
       Fiber.yield ps, self

--- a/mrblib/yarn.rb
+++ b/mrblib/yarn.rb
@@ -65,7 +65,7 @@ module UV
     end
 
     def sleep sec
-      timer.start(sec * 1000.0, 0, &self)
+      timer.start(sec * 1000.0, 0, &self.to_proc)
       Fiber.yield(timer, self)
     end
 

--- a/mrblib/yarn.rb
+++ b/mrblib/yarn.rb
@@ -1,0 +1,95 @@
+module UV
+  def self.sleep sec
+    current_yarn.sleep sec
+  end
+
+  def self.current_yarn
+    ret = UV.current_loop.current_yarn
+    raise "yarn not running" if ret.nil?
+    ret
+  end
+
+  class Loop
+    attr_reader :current_yarn
+
+    def current_yarn=(y)
+      raise "cannot double run yarn" if current_yarn
+      raise "not yarn" unless y.kind_of? UV::Yarn
+
+      @current_yarn = y
+    end
+
+    def clear_current_yarn
+      @current_yarn = nil
+    end
+  end
+
+  class Yarn
+    def initialize(loop = UV.current_loop, &blk)
+      @fiber = Fiber.new(&blk)
+      @loop = loop
+    end
+
+    attr_reader :loop, :error
+
+    def ended?; @fiber.nil? end
+    def result
+      raise "not ended" unless ended?
+      @result
+    end
+
+    def check_error
+      raise @error if @error
+    end
+
+    def timer
+      @timer ||= UV::Timer.new
+      # raise 'timer already used' if @timer.active?
+      @timer
+    end
+
+    def to_proc
+      @proc ||= Proc.new{|*args, &blk| self.resume(*args, &blk) }
+    end
+
+    def start(*args)
+      raise "already started" if @started
+      @started = true
+
+      resume(*args)
+    end
+
+    def sleep sec
+      timer.start(sec * 1000.0, 0) do
+        self.resume
+      end
+      Fiber.yield(timer, self)
+    end
+
+    def resume(*args)
+      raise "cannot resume unstarted yarn" unless @started
+      raise "cannot run ended yarn" if ended?
+
+      @loop.current_yarn = self
+
+      prev_loop = UV.current_loop
+      @loop.make_current
+
+      *ret = @fiber.resume(*args)
+
+      if @fiber.alive?
+        raise "invalid yield" if !ret.first.kind_of?(UV::Req) && !ret.first.kind_of?(UV::Timer)
+      else
+        @fiber = nil
+        @result = ret
+      end
+
+    rescue => e
+      @error = e
+
+    ensure
+      @loop.clear_current_yarn
+      prev_loop.make_current if prev_loop
+    end
+  end
+end

--- a/src/fs.c
+++ b/src/fs.c
@@ -310,7 +310,7 @@ mrb_uv_fs_read(mrb_state *mrb, mrb_value self)
 
   mrb_get_args(mrb, "&|ii", &b, &arg_length, &arg_offset);
 
-  buf_str = mrb_str_resize(mrb, mrb_str_new_capa(mrb, arg_length), arg_length);
+  buf_str = mrb_str_resize(mrb, mrb_str_buf_new(mrb, arg_length), arg_length);
   req = mrb_uv_req_current(mrb, b, &ret);
   mrb_uv_req_set_buf(req, &buf, buf_str);
   res = uv_fs_read(mrb_uv_current_loop(mrb), &req->req.fs, context->fd,

--- a/src/fs.c
+++ b/src/fs.c
@@ -89,10 +89,14 @@ mrb_uv_fs_free(mrb_state *mrb, void *p)
   }
 }
 
-
 static const struct mrb_data_type mrb_uv_file_type = {
   "uv_file", mrb_uv_fs_free
 };
+
+void mrb_uv_fs_req_free(mrb_state *mrb, uv_fs_t *req) {
+  uv_fs_req_cleanup(req);
+  mrb_free(mrb, req);
+}
 
 uv_file
 mrb_uv_to_fd(mrb_state *mrb, mrb_value v)
@@ -118,8 +122,7 @@ _uv_fs_open_cb(uv_fs_t* req)
     args[0] = mrb_fixnum_value(req->result);
     mrb_yield_argv(mrb, proc, 1, args);
   }
-  uv_fs_req_cleanup(req);
-  mrb_free(mrb, req);
+  mrb_uv_fs_req_free(mrb, req);
 }
 
 static mrb_value
@@ -197,8 +200,7 @@ _uv_fs_cb(uv_fs_t* req)
     break;
   }
 leave:
-  uv_fs_req_cleanup(req);
-  mrb_free(mrb, req);
+  mrb_uv_fs_req_free(mrb, req);
 }
 
 static mrb_value
@@ -483,8 +485,7 @@ mrb_uv_fs_scandir(mrb_state *mrb, mrb_value self)
     while (uv_fs_scandir_next(req, &ent) != UV_EOF) {
       mrb_ary_push(mrb, ret, mrb_assoc_new(mrb, mrb_str_new_cstr(mrb, ent.name), dirtype_to_sym(mrb, ent.type)));
     }
-    uv_fs_req_cleanup(req);
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     return ret;
   }
   return self;
@@ -521,8 +522,7 @@ mrb_uv_fs_stat(mrb_state *mrb, mrb_value self)
 
   if (mrb_nil_p(b)) {
     mrb_value ret = mrb_uv_create_stat(mrb, &req->statbuf);
-    uv_fs_req_cleanup(req);
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     return ret;
   }
   return self;
@@ -555,8 +555,7 @@ mrb_uv_fs_fstat(mrb_state *mrb, mrb_value self)
 
   if (mrb_nil_p(b)) {
     mrb_value ret = mrb_uv_create_stat(mrb, &req->statbuf);
-    uv_fs_req_cleanup(req);
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     return ret;
   }
   return self;
@@ -593,8 +592,7 @@ mrb_uv_fs_lstat(mrb_state *mrb, mrb_value self)
 
   if (mrb_nil_p(b)) {
     mrb_value ret = mrb_uv_create_stat(mrb, &req->statbuf);
-    uv_fs_req_cleanup(req);
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     return ret;
   }
   return self;
@@ -836,8 +834,7 @@ mrb_uv_fs_utime(mrb_state *mrb, mrb_value self)
     mrb_uv_check_error(mrb, err);
   }
   if (mrb_nil_p(b)) {
-    uv_fs_req_cleanup(req);
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
   }
   return self;
 }
@@ -866,8 +863,7 @@ mrb_uv_fs_futime(mrb_state *mrb, mrb_value self)
     mrb_uv_check_error(mrb, err);
   }
   if (mrb_nil_p(b)) {
-    uv_fs_req_cleanup(req);
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
   }
   return self;
 }
@@ -897,8 +893,7 @@ mrb_uv_fs_fchmod(mrb_state *mrb, mrb_value self)
   }
 
   if (mrb_nil_p(b)) {
-    uv_fs_req_cleanup(req);
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
   }
   return self;
 }
@@ -931,8 +926,7 @@ mrb_uv_fs_symlink(mrb_state *mrb, mrb_value self)
   }
 
   if (mrb_nil_p(b)) {
-    uv_fs_req_cleanup(req);
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
   }
   return self;
 }
@@ -965,8 +959,7 @@ mrb_uv_fs_readlink(mrb_state *mrb, mrb_value self)
 
   if (mrb_nil_p(b)) {
     mrb_value const ret = mrb_str_new_cstr(mrb, req->ptr);
-    uv_fs_req_cleanup(req);
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     return ret;
   }
   return self;
@@ -1000,8 +993,7 @@ mrb_uv_fs_realpath(mrb_state *mrb, mrb_value self)
 
   if (mrb_nil_p(b)) {
     mrb_value const ret = mrb_str_new_cstr(mrb, req->ptr);
-    uv_fs_req_cleanup(req);
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     return ret;
   }
   return self;
@@ -1028,8 +1020,7 @@ mrb_uv_fs_chown(mrb_state *mrb, mrb_value self)
   }
 
   if (mrb_nil_p(b)) {
-    uv_fs_req_cleanup(req);
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
   }
   return self;
 }
@@ -1055,8 +1046,7 @@ mrb_uv_fs_fchown(mrb_state *mrb, mrb_value self)
   }
 
   if (mrb_nil_p(b)) {
-    uv_fs_req_cleanup(req);
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
   }
   return self;
 }
@@ -1109,7 +1099,7 @@ mrb_uv_fs_mkdtemp(mrb_state *mrb, mrb_value self)
     mrb_value ret;
     mrb_uv_check_error(mrb, uv_fs_mkdtemp(uv_default_loop(), &req, tmp, NULL));
     ret = mrb_str_new_cstr(mrb, req.path);
-    free((char*)req.path);
+    uv_fs_req_cleanup(&req);
     return ret;
   } else {
     mrb_value req_val = mrb_uv_req_alloc(mrb, UV_FS, proc);

--- a/src/fs.c
+++ b/src/fs.c
@@ -84,7 +84,7 @@ mrb_uv_fs_free(mrb_state *mrb, void *p)
   if (ctx) {
     uv_fs_t req;
     req.data = ctx;
-    uv_fs_close(uv_default_loop(), &req, ctx->fd, NULL);
+    uv_fs_close(mrb_uv_current_loop(mrb), &req, ctx->fd, NULL);
     mrb_free(mrb, ctx);
   }
 }
@@ -187,7 +187,7 @@ _uv_fs_cb(uv_fs_t* req)
 
   default:
     if (req->fs_type == UV_FS_READ && req->result == 0) {
-      uv_fs_close(uv_default_loop(), &close_req, context->fd, NULL);
+      uv_fs_close(mrb_uv_current_loop(mrb), &close_req, context->fd, NULL);
       goto leave;
     }
     if (!mrb_nil_p(proc)) {
@@ -245,7 +245,7 @@ mrb_uv_fs_open(mrb_state *mrb, mrb_value self)
   req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
   memset(req, 0, sizeof(uv_fs_t));
   req->data = context;
-  context->fd = uv_fs_open(uv_default_loop(), req, RSTRING_PTR(arg_filename), arg_flags, arg_mode, fs_cb);
+  context->fd = uv_fs_open(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_filename), arg_flags, arg_mode, fs_cb);
   if (context->fd < 0 || !fs_cb) {
     mrb_free(mrb, req);
     mrb_uv_check_error(mrb, context->fd);
@@ -273,7 +273,7 @@ mrb_uv_fs_close(mrb_state *mrb, mrb_value self)
   req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
   memset(req, 0, sizeof(uv_fs_t));
   req->data = context;
-  err = uv_fs_close(uv_default_loop(), req, context->fd, fs_cb);
+  err = uv_fs_close(mrb_uv_current_loop(mrb), req, context->fd, fs_cb);
   if (err < 0 || !fs_cb) {
     mrb_free(mrb, req);
     mrb_uv_check_error(mrb, context->fd);
@@ -310,7 +310,7 @@ mrb_uv_fs_write(mrb_state *mrb, mrb_value self)
     arg_offset = 0;
   buf.base = RSTRING_PTR(arg_data);
   buf.len = arg_length;
-  r = uv_fs_write(uv_default_loop(), req, context->fd, &buf, 1, arg_offset, fs_cb);
+  r = uv_fs_write(mrb_uv_current_loop(mrb), req, context->fd, &buf, 1, arg_offset, fs_cb);
   if (r < 0 || !fs_cb) {
     mrb_free(mrb, req);
     mrb_uv_check_error(mrb, r);
@@ -345,7 +345,7 @@ mrb_uv_fs_read(mrb_state *mrb, mrb_value self)
   }
   memset(req, 0, sizeof(uv_fs_t));
   req->data = context;
-  len = uv_fs_read(uv_default_loop(), req, context->fd, &buf, 1, arg_offset, fs_cb);
+  len = uv_fs_read(mrb_uv_current_loop(mrb), req, context->fd, &buf, 1, arg_offset, fs_cb);
   if (len < 0) {
     mrb_free(mrb, buf.base);
     mrb_free(mrb, req);
@@ -385,7 +385,7 @@ mrb_uv_fs_unlink(mrb_state *mrb, mrb_value self)
   req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
   memset(req, 0, sizeof(uv_fs_t));
   req->data = &context;
-  err = uv_fs_unlink(uv_default_loop(), req, RSTRING_PTR(arg_path), fs_cb);
+  err = uv_fs_unlink(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_path), fs_cb);
   if (err != 0 || !fs_cb) {
     mrb_free(mrb, req);
     mrb_uv_check_error(mrb, err);
@@ -417,7 +417,7 @@ mrb_uv_fs_mkdir(mrb_state *mrb, mrb_value self)
   req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
   memset(req, 0, sizeof(uv_fs_t));
   req->data = &context;
-  err = uv_fs_mkdir(uv_default_loop(), req, RSTRING_PTR(arg_path), arg_mode, fs_cb);
+  err = uv_fs_mkdir(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_path), arg_mode, fs_cb);
   if (err != 0 || !fs_cb) {
     mrb_free(mrb, req);
     mrb_uv_check_error(mrb, err);
@@ -448,7 +448,7 @@ mrb_uv_fs_rmdir(mrb_state *mrb, mrb_value self)
   req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
   memset(req, 0, sizeof(uv_fs_t));
   req->data = &context;
-  err = uv_fs_rmdir(uv_default_loop(), req, RSTRING_PTR(arg_path), fs_cb);
+  err = uv_fs_rmdir(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_path), fs_cb);
   if (err != 0 || !fs_cb) {
     mrb_free(mrb, req);
     mrb_uv_check_error(mrb, err);
@@ -475,7 +475,7 @@ mrb_uv_fs_scandir(mrb_state *mrb, mrb_value self)
 
   req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
   req->data = &context;
-  err = uv_fs_scandir(uv_default_loop(), req, mrb_string_value_ptr(mrb, arg_path),
+  err = uv_fs_scandir(mrb_uv_current_loop(mrb), req, mrb_string_value_ptr(mrb, arg_path),
                       arg_flags, mrb_nil_p(b)? NULL : _uv_fs_cb);
   if (err < 0) {
     mrb_free(mrb, req);
@@ -516,7 +516,7 @@ mrb_uv_fs_stat(mrb_state *mrb, mrb_value self)
   req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
   memset(req, 0, sizeof(uv_fs_t));
   req->data = &context;
-  err = uv_fs_stat(uv_default_loop(), req, RSTRING_PTR(arg_path), fs_cb);
+  err = uv_fs_stat(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_path), fs_cb);
   if (err != 0) {
     mrb_free(mrb, req);
     mrb_uv_check_error(mrb, err);
@@ -549,7 +549,7 @@ mrb_uv_fs_fstat(mrb_state *mrb, mrb_value self)
   req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
   memset(req, 0, sizeof(uv_fs_t));
   req->data = &context;
-  err = uv_fs_fstat(uv_default_loop(), req, context->fd, fs_cb);
+  err = uv_fs_fstat(mrb_uv_current_loop(mrb), req, context->fd, fs_cb);
   if (err != 0) {
     mrb_free(mrb, req);
     mrb_uv_check_error(mrb, err);
@@ -586,7 +586,7 @@ mrb_uv_fs_lstat(mrb_state *mrb, mrb_value self)
   req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
   memset(req, 0, sizeof(uv_fs_t));
   req->data = &context;
-  err = uv_fs_lstat(uv_default_loop(), req, RSTRING_PTR(arg_path), fs_cb);
+  err = uv_fs_lstat(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_path), fs_cb);
   if (err != 0) {
     mrb_free(mrb, req);
     mrb_uv_check_error(mrb, err);
@@ -623,7 +623,7 @@ mrb_uv_fs_rename(mrb_state *mrb, mrb_value self)
   req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
   memset(req, 0, sizeof(uv_fs_t));
   req->data = &context;
-  err = uv_fs_rename(uv_default_loop(), req, RSTRING_PTR(arg_path), RSTRING_PTR(arg_new_path), fs_cb);
+  err = uv_fs_rename(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_path), RSTRING_PTR(arg_new_path), fs_cb);
   if (err != 0) {
     mrb_free(mrb, req);
     mrb_uv_check_error(mrb, err);
@@ -650,7 +650,7 @@ mrb_uv_fs_fsync(mrb_state *mrb, mrb_value self)
   req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
   memset(req, 0, sizeof(uv_fs_t));
   req->data = &context;
-  err = uv_fs_fsync(uv_default_loop(), req, context->fd, fs_cb);
+  err = uv_fs_fsync(mrb_uv_current_loop(mrb), req, context->fd, fs_cb);
   if (err != 0) {
     mrb_free(mrb, req);
     mrb_uv_check_error(mrb, err);
@@ -677,7 +677,7 @@ mrb_uv_fs_fdatasync(mrb_state *mrb, mrb_value self)
   req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
   memset(req, 0, sizeof(uv_fs_t));
   req->data = &context;
-  err = uv_fs_fdatasync(uv_default_loop(), req, context->fd, fs_cb);
+  err = uv_fs_fdatasync(mrb_uv_current_loop(mrb), req, context->fd, fs_cb);
   if (err != 0) {
     mrb_free(mrb, req);
     mrb_uv_check_error(mrb, err);
@@ -705,7 +705,7 @@ mrb_uv_fs_ftruncate(mrb_state *mrb, mrb_value self)
   req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
   memset(req, 0, sizeof(uv_fs_t));
   req->data = &context;
-  err = uv_fs_ftruncate(uv_default_loop(), req, context->fd, arg_offset, fs_cb);
+  err = uv_fs_ftruncate(mrb_uv_current_loop(mrb), req, context->fd, arg_offset, fs_cb);
   if (err != 0) {
     mrb_free(mrb, req);
     mrb_uv_check_error(mrb, err);
@@ -738,7 +738,7 @@ mrb_uv_fs_sendfile(mrb_state *mrb, mrb_value self)
   req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
   memset(req, 0, sizeof(uv_fs_t));
   req->data = &context;
-  err = uv_fs_sendfile(uv_default_loop(), req, arg_infd, arg_outfd, arg_offset, arg_length, fs_cb);
+  err = uv_fs_sendfile(mrb_uv_current_loop(mrb), req, arg_infd, arg_outfd, arg_offset, arg_length, fs_cb);
   if (err != 0) {
     mrb_free(mrb, req);
     mrb_uv_check_error(mrb, err);
@@ -770,7 +770,7 @@ mrb_uv_fs_chmod(mrb_state *mrb, mrb_value self)
   req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
   memset(req, 0, sizeof(uv_fs_t));
   req->data = &context;
-  err = uv_fs_chmod(uv_default_loop(), req, RSTRING_PTR(arg_path), arg_mode, fs_cb);
+  err = uv_fs_chmod(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_path), arg_mode, fs_cb);
   if (err != 0) {
     mrb_free(mrb, req);
     mrb_uv_check_error(mrb, err);
@@ -801,7 +801,7 @@ mrb_uv_fs_link(mrb_state *mrb, mrb_value self)
   req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
   memset(req, 0, sizeof(uv_fs_t));
   req->data = &context;
-  err = uv_fs_link(uv_default_loop(), req, RSTRING_PTR(arg_path), RSTRING_PTR(arg_new_path), fs_cb);
+  err = uv_fs_link(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_path), RSTRING_PTR(arg_new_path), fs_cb);
   if (err != 0) {
     mrb_free(mrb, req);
     mrb_uv_check_error(mrb, err);
@@ -830,7 +830,7 @@ mrb_uv_fs_utime(mrb_state *mrb, mrb_value self)
 
   req = (uv_fs_t*)mrb_malloc(mrb, sizeof(uv_fs_t));
   req->data = &context;
-  err = uv_fs_utime(uv_default_loop(), req, path, (double)atime, (double)mtime, mrb_nil_p(b)? NULL : _uv_fs_cb);
+  err = uv_fs_utime(mrb_uv_current_loop(mrb), req, path, (double)atime, (double)mtime, mrb_nil_p(b)? NULL : _uv_fs_cb);
   if (err < 0) {
     mrb_free(mrb, req);
     mrb_uv_check_error(mrb, err);
@@ -859,7 +859,7 @@ mrb_uv_fs_futime(mrb_state *mrb, mrb_value self)
   ctx = (mrb_uv_file*)mrb_uv_get_ptr(mrb, self, &mrb_uv_file_type);
   req = (uv_fs_t*)mrb_malloc(mrb, sizeof(uv_fs_t));
   req->data = ctx;
-  err = uv_fs_futime(uv_default_loop(), req, ctx->fd, (double)atime, (double)mtime, mrb_nil_p(b)? NULL : _uv_fs_cb);
+  err = uv_fs_futime(mrb_uv_current_loop(mrb), req, ctx->fd, (double)atime, (double)mtime, mrb_nil_p(b)? NULL : _uv_fs_cb);
   if (err < 0) {
     mrb_free(mrb, req);
     mrb_uv_check_error(mrb, err);
@@ -888,7 +888,7 @@ mrb_uv_fs_fchmod(mrb_state *mrb, mrb_value self)
   ctx = (mrb_uv_file*)mrb_uv_get_ptr(mrb, self, &mrb_uv_file_type);
   req = (uv_fs_t*)mrb_malloc(mrb, sizeof(uv_fs_t));
   req->data = ctx;
-  err = uv_fs_fchmod(uv_default_loop(), req, ctx->fd, mode, mrb_nil_p(b)? NULL : _uv_fs_cb);
+  err = uv_fs_fchmod(mrb_uv_current_loop(mrb), req, ctx->fd, mode, mrb_nil_p(b)? NULL : _uv_fs_cb);
   if (err < 0) {
     mrb_free(mrb, req);
     mrb_uv_check_error(mrb, err);
@@ -921,7 +921,7 @@ mrb_uv_fs_symlink(mrb_state *mrb, mrb_value self)
 
   req = (uv_fs_t*)mrb_malloc(mrb, sizeof(uv_fs_t));
   req->data = &ctx;
-  err = uv_fs_symlink(uv_default_loop(), req, path, new_path, flags, mrb_nil_p(b)? NULL : _uv_fs_cb);
+  err = uv_fs_symlink(mrb_uv_current_loop(mrb), req, path, new_path, flags, mrb_nil_p(b)? NULL : _uv_fs_cb);
   if (err < 0) {
     mrb_free(mrb, req);
     mrb_uv_check_error(mrb, err);
@@ -953,7 +953,7 @@ mrb_uv_fs_readlink(mrb_state *mrb, mrb_value self)
 
   req = (uv_fs_t*)mrb_malloc(mrb, sizeof(uv_fs_t));
   req->data = &ctx;
-  err = uv_fs_readlink(uv_default_loop(), req, path, mrb_nil_p(b)? NULL : _uv_fs_cb);
+  err = uv_fs_readlink(mrb_uv_current_loop(mrb), req, path, mrb_nil_p(b)? NULL : _uv_fs_cb);
   if (err < 0) {
     mrb_free(mrb, req);
     mrb_uv_check_error(mrb, err);
@@ -989,7 +989,7 @@ mrb_uv_fs_realpath(mrb_state *mrb, mrb_value self)
 
   req = (uv_fs_t*)mrb_malloc(mrb, sizeof(uv_fs_t));
   req->data = &ctx;
-  err = uv_fs_realpath(uv_default_loop(), req, path, mrb_nil_p(b)? NULL : _uv_fs_cb);
+  err = uv_fs_realpath(mrb_uv_current_loop(mrb), req, path, mrb_nil_p(b)? NULL : _uv_fs_cb);
   if (err < 0) {
     mrb_free(mrb, req);
     mrb_uv_check_error(mrb, err);
@@ -1019,7 +1019,7 @@ mrb_uv_fs_chown(mrb_state *mrb, mrb_value self)
 
   req = (uv_fs_t*)mrb_malloc(mrb, sizeof(uv_fs_t));
   req->data = &ctx;
-  err = uv_fs_chown(uv_default_loop(), req, path, (uv_uid_t)uid, (uv_gid_t)gid, mrb_nil_p(b)? NULL : _uv_fs_cb);
+  err = uv_fs_chown(mrb_uv_current_loop(mrb), req, path, (uv_uid_t)uid, (uv_gid_t)gid, mrb_nil_p(b)? NULL : _uv_fs_cb);
   if (err < 0) {
     mrb_free(mrb, req);
     mrb_uv_check_error(mrb, err);
@@ -1045,7 +1045,7 @@ mrb_uv_fs_fchown(mrb_state *mrb, mrb_value self)
   ctx = (mrb_uv_file*)mrb_uv_get_ptr(mrb, self, &mrb_uv_file_type);
   req = (uv_fs_t*)mrb_malloc(mrb, sizeof(uv_fs_t));
   req->data = ctx;
-  err = uv_fs_fchown(uv_default_loop(), req, ctx->fd, (uv_uid_t)uid, (uv_gid_t)gid, mrb_nil_p(b)? NULL : _uv_fs_cb);
+  err = uv_fs_fchown(mrb_uv_current_loop(mrb), req, ctx->fd, (uv_uid_t)uid, (uv_gid_t)gid, mrb_nil_p(b)? NULL : _uv_fs_cb);
   if (err < 0) {
     mrb_free(mrb, req);
     mrb_uv_check_error(mrb, err);
@@ -1105,14 +1105,14 @@ mrb_uv_fs_mkdtemp(mrb_state *mrb, mrb_value self)
   if (mrb_nil_p(proc)) {
     uv_fs_t req;
     mrb_value ret;
-    mrb_uv_check_error(mrb, uv_fs_mkdtemp(uv_default_loop(), &req, tmp, NULL));
+    mrb_uv_check_error(mrb, uv_fs_mkdtemp(mrb_uv_current_loop(mrb), &req, tmp, NULL));
     ret = mrb_str_new_cstr(mrb, req.path);
     uv_fs_req_cleanup(&req);
     return ret;
   } else {
     mrb_value req_val = mrb_uv_req_alloc(mrb, UV_FS, proc);
     mrb_uv_req_t *req = (mrb_uv_req_t*)DATA_PTR(req_val);
-    mrb_uv_check_error(mrb, uv_fs_mkdtemp(uv_default_loop(), (uv_fs_t*)&req->req, tmp, fs_req_cb));
+    mrb_uv_check_error(mrb, uv_fs_mkdtemp(mrb_uv_current_loop(mrb), (uv_fs_t*)&req->req, tmp, fs_req_cb));
     return req_val;
   }
 }
@@ -1129,7 +1129,7 @@ mrb_uv_fs_access(mrb_state *mrb, mrb_value self)
     uv_fs_t req;
     int res;
 
-    res = uv_fs_access(uv_default_loop(), &req, path, flags, NULL);
+    res = uv_fs_access(mrb_uv_current_loop(mrb), &req, path, flags, NULL);
     switch(res) {
     case 0: return mrb_true_value();
     case UV_EPERM: return mrb_false_value();
@@ -1144,7 +1144,7 @@ mrb_uv_fs_access(mrb_state *mrb, mrb_value self)
   } else {
     mrb_value req_val = mrb_uv_req_alloc(mrb, UV_FS, proc);
     mrb_uv_req_t *req = (mrb_uv_req_t*)DATA_PTR(req_val);
-    mrb_uv_check_error(mrb, uv_fs_access(uv_default_loop(), (uv_fs_t*)&req->req, path, flags, fs_req_cb));
+    mrb_uv_check_error(mrb, uv_fs_access(mrb_uv_current_loop(mrb), (uv_fs_t*)&req->req, path, flags, fs_req_cb));
     return req_val;
   }
 }
@@ -1161,12 +1161,12 @@ mrb_uv_fs_copyfile(mrb_state *mrb, mrb_value self)
   mrb_get_args(mrb, "&zz|i", &proc, &old_path, &new_path, &flags);
   if (mrb_nil_p(proc)) {
     uv_fs_t req;
-    mrb_uv_check_error(mrb, uv_fs_copyfile(uv_default_loop(), &req, old_path, new_path, flags, NULL));
+    mrb_uv_check_error(mrb, uv_fs_copyfile(mrb_uv_current_loop(mrb), &req, old_path, new_path, flags, NULL));
     return mrb_nil_value();
   } else {
     mrb_value req_val = mrb_uv_req_alloc(mrb, UV_FS, proc);
     mrb_uv_req_t *req = (mrb_uv_req_t*)DATA_PTR(req_val);
-    mrb_uv_check_error(mrb, uv_fs_copyfile(uv_default_loop(), (uv_fs_t*)&req->req, old_path, new_path, flags, fs_req_cb));
+    mrb_uv_check_error(mrb, uv_fs_copyfile(mrb_uv_current_loop(mrb), (uv_fs_t*)&req->req, old_path, new_path, flags, fs_req_cb));
     return req_val;
   }
 }

--- a/src/fs.c
+++ b/src/fs.c
@@ -84,7 +84,7 @@ mrb_uv_fs_free(mrb_state *mrb, void *p)
   if (ctx) {
     uv_fs_t req;
     req.data = ctx;
-    uv_fs_close(mrb_uv_current_loop(mrb), &req, ctx->fd, NULL);
+    uv_fs_close(NULL, &req, ctx->fd, NULL);
     mrb_free(mrb, ctx);
   }
 }
@@ -92,11 +92,6 @@ mrb_uv_fs_free(mrb_state *mrb, void *p)
 static const struct mrb_data_type mrb_uv_file_type = {
   "uv_file", mrb_uv_fs_free
 };
-
-void mrb_uv_fs_req_free(mrb_state *mrb, uv_fs_t *req) {
-  uv_fs_req_cleanup(req);
-  mrb_free(mrb, req);
-}
 
 uv_file
 mrb_uv_to_fd(mrb_state *mrb, mrb_value v)
@@ -106,23 +101,6 @@ mrb_uv_to_fd(mrb_state *mrb, mrb_value v)
   }
 
   return ((mrb_uv_file*)mrb_uv_get_ptr(mrb, v, &mrb_uv_file_type))->fd;
-}
-
-static void
-_uv_fs_open_cb(uv_fs_t* req)
-{
-  mrb_uv_file *context = (mrb_uv_file*)req->data;
-  mrb_state* mrb = context->mrb;
-  mrb_value proc;
-  mrb_uv_check_error(mrb, req->result);
-  proc = mrb_iv_get(mrb, context->instance, mrb_intern_lit(mrb, "fs_cb"));
-  if (!mrb_nil_p(proc)) {
-    mrb_value args[1];
-    context->fd = req->result;
-    args[0] = mrb_fixnum_value(req->result);
-    mrb_yield_argv(mrb, proc, 1, args);
-  }
-  mrb_uv_fs_req_free(mrb, req);
 }
 
 static mrb_value
@@ -144,65 +122,77 @@ dirtype_to_sym(mrb_state *mrb, uv_dirent_type_t t)
   return mrb_symbol_value(ret);
 }
 
-static void
-_uv_fs_cb(uv_fs_t* req)
+static mrb_value
+dir_to_array(mrb_state *mrb, uv_fs_t *req)
 {
-  mrb_uv_file* context = (mrb_uv_file*) req->data;
-  mrb_state* mrb = context->mrb;
-  mrb_value proc;
-  uv_fs_t close_req;
-  mrb_uv_check_error(mrb, req->result);
-  proc = mrb_iv_get(mrb, context->instance, mrb_intern_lit(mrb, "fs_cb"));
+  mrb_value ret = mrb_ary_new_capa(mrb, req->result);
+  int ai = mrb_gc_arena_save(mrb);
+  uv_dirent_t ent;
 
-  switch (req->fs_type) {
-  case UV_FS_SCANDIR:
-    if (!mrb_nil_p(proc)) {
-      mrb_value ary = mrb_ary_new_capa(mrb, req->result);
-      uv_dirent_t ent;
-      while (uv_fs_scandir_next(req, &ent) != UV_EOF) {
-        mrb_ary_push(mrb, ary, mrb_assoc_new(mrb, mrb_str_new_cstr(mrb, ent.name), dirtype_to_sym(mrb, ent.type)));
-      }
-      mrb_yield_argv(mrb, proc, 1, &ary);
-    }
-    break;
+  while (uv_fs_scandir_next(req, &ent) != UV_EOF) {
+    mrb_ary_push(mrb, ret, mrb_assoc_new(mrb, mrb_str_new_cstr(mrb, ent.name), dirtype_to_sym(mrb, ent.type)));
+    mrb_gc_arena_restore(mrb, ai);
+  }
+
+  return ret;
+}
+
+static void
+_uv_fs_cb(uv_fs_t* uv_req)
+{
+  mrb_uv_req_t* req = (mrb_uv_req_t*) uv_req->data;
+  mrb_state* mrb = req->mrb;
+
+  mrb_assert(!mrb_nil_p(req->block));
+
+  if (uv_req->result < 0) {
+    mrb_value const err = mrb_uv_create_error(mrb, uv_req->result);
+    mrb_uv_req_yield(req, 1, &err);
+    return;
+  }
+
+  switch (uv_req->fs_type) {
+  case UV_FS_MKDTEMP: {
+    mrb_value const str = mrb_str_new_cstr(mrb, uv_req->path);
+    mrb_uv_req_yield(req, 1, &str);
+  } break;
+
+  case UV_FS_ACCESS: {
+    mrb_value const arg = mrb_uv_create_status(mrb, uv_req->result);
+    mrb_uv_req_yield(req, 1, &arg);
+  } break;
+
+#if MRB_UV_CHECK_VERSION(1, 14, 0)
+  case UV_FS_COPYFILE: {
+    mrb_uv_req_yield(req, 0, NULL);
+  } break;
+#endif
+
+  case UV_FS_SCANDIR: {
+    mrb_value const ary = dir_to_array(mrb, uv_req);
+    mrb_uv_req_yield(req, 1, &ary);
+  } break;
 
 #if MRB_UV_CHECK_VERSION(1, 8, 0)
   case UV_FS_REALPATH:
 #endif
   case UV_FS_READLINK: {
-    mrb_value res;
-    mrb_assert(!mrb_nil_p(proc));
-    res = mrb_str_new_cstr(mrb, req->ptr);
-    mrb_yield_argv(mrb, proc, 1, &res);
+    mrb_value const res = mrb_str_new_cstr(mrb, uv_req->ptr);
+    mrb_uv_req_yield(req, 1, &res);
   } break;
 
   case UV_FS_STAT:
   case UV_FS_FSTAT:
   case UV_FS_LSTAT: {
-    mrb_value res;
-    mrb_assert(!mrb_nil_p(proc));
-    res = mrb_uv_create_stat(mrb, &req->statbuf);
-    mrb_yield_argv(mrb, proc, 1, &res);
+    mrb_value const res = mrb_uv_create_stat(mrb, &uv_req->statbuf);
+    mrb_uv_req_yield(req, 1, &res);
   } break;
 
-  default:
-    if (req->fs_type == UV_FS_READ && req->result == 0) {
-      uv_fs_close(mrb_uv_current_loop(mrb), &close_req, context->fd, NULL);
-      goto leave;
-    }
-    if (!mrb_nil_p(proc)) {
-       mrb_value args[1];
-       args[0] = mrb_fixnum_value(req->result);
-       mrb_yield_argv(mrb, proc, 1, args);
-    }
-    if (req->fs_type == UV_FS_CLOSE) {
-      DATA_PTR(context->instance) = NULL;
-      mrb_free(mrb, context);
-    }
-    break;
+  default: {
+      mrb_value const res = mrb_fixnum_value(uv_req->result);
+      mrb_uv_req_yield(req, 1, &res);
+    } break;
   }
-leave:
-  mrb_uv_fs_req_free(mrb, req);
 }
 
 static mrb_value
@@ -212,73 +202,72 @@ mrb_uv_fs_fd(mrb_state *mrb, mrb_value self)
   return mrb_fixnum_value(ctx->fd);
 }
 
+static void
+_uv_fs_open_cb(uv_fs_t* uv_req)
+{
+  mrb_uv_req_t *req = (mrb_uv_req_t*)uv_req->data;
+  mrb_state* mrb = req->mrb;
+  mrb_value args[2];
+  mrb_uv_file *file;
+
+  args[0] = mrb_iv_get(mrb, req->instance, mrb_intern_lit(mrb, "fs_open"));
+  args[1] = mrb_uv_create_status(mrb, uv_req->result);
+  mrb_iv_set(mrb, req->instance, mrb_intern_lit(mrb, "fs_open"), mrb_nil_value());
+  file = (mrb_uv_file*)DATA_PTR(args[0]);
+  file->fd = uv_req->result;
+  mrb_uv_req_yield(req, 2, args);
+}
+
 static mrb_value
 mrb_uv_fs_open(mrb_state *mrb, mrb_value self)
 {
-  mrb_value arg_filename = mrb_nil_value();
+  char const *arg_filename;
+  mrb_value c, b, ret;
   mrb_int arg_flags, arg_mode;
-  uv_fs_cb fs_cb = _uv_fs_open_cb;
-  mrb_value b = mrb_nil_value();
-  struct RClass* _class_uv;
   struct RClass* _class_uv_fs;
-  mrb_value c;
   mrb_uv_file* context;
-  uv_fs_t* req;
+  mrb_uv_req_t* req;
+  int res;
 
-  mrb_get_args(mrb, "&Sii", &b, &arg_filename, &arg_flags, &arg_mode);
+  mrb_get_args(mrb, "&zii", &b, &arg_filename, &arg_flags, &arg_mode);
 
-  _class_uv = mrb_module_get(mrb, "UV");
-  _class_uv_fs = mrb_class_get_under(mrb, _class_uv, "FS");
+  _class_uv_fs = mrb_class_get_under(mrb, mrb_module_get(mrb, "UV"), "FS");
   c = mrb_obj_value(mrb_obj_alloc(mrb, MRB_TT_DATA, _class_uv_fs));
-
   context = (mrb_uv_file*)mrb_malloc(mrb, sizeof(mrb_uv_file));
   context->mrb = mrb;
   context->instance = c;
-  if (mrb_nil_p(b)) {
-    fs_cb = NULL;
-  }
-  mrb_iv_set(mrb, c, mrb_intern_lit(mrb, "fs_cb"), b);
-
+  context->fd = -1;
   DATA_PTR(c) = context;
   DATA_TYPE(c) = &mrb_uv_file_type;
 
-  req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
-  memset(req, 0, sizeof(uv_fs_t));
-  req->data = context;
-  context->fd = uv_fs_open(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_filename), arg_flags, arg_mode, fs_cb);
-  if (context->fd < 0 || !fs_cb) {
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, context->fd);
+  req = mrb_uv_req_current(mrb, b, &ret);
+  res = uv_fs_open(mrb_uv_current_loop(mrb), &req->req.fs,
+                   arg_filename, arg_flags, arg_mode, mrb_nil_p(req->block)? NULL : _uv_fs_open_cb);
+  mrb_uv_req_check_error(mrb, req, res);
+  if (mrb_nil_p(req->block)) {
+    context->fd = res;
+    return c;
   }
-
-  mrb_uv_gc_protect(mrb, c);
-  return c;
+  mrb_iv_set(mrb, req->instance, mrb_intern_lit(mrb, "fs_open"), c);
+  return ret;
 }
 
 static mrb_value
 mrb_uv_fs_close(mrb_state *mrb, mrb_value self)
 {
   mrb_uv_file* context = (mrb_uv_file*)mrb_uv_get_ptr(mrb, self, &mrb_uv_file_type);
-  mrb_value b = mrb_nil_value();
-  uv_fs_cb fs_cb = _uv_fs_cb;
-  uv_fs_t* req;
-  int err;
+  mrb_value b, ret;
+  mrb_uv_req_t *req;
 
   mrb_get_args(mrb, "&", &b);
-  if (mrb_nil_p(b)) {
-    fs_cb = NULL;
-  }
-  mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "fs_cb"), b);
 
-  req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
-  memset(req, 0, sizeof(uv_fs_t));
-  req->data = context;
-  err = uv_fs_close(mrb_uv_current_loop(mrb), req, context->fd, fs_cb);
-  if (err < 0 || !fs_cb) {
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, context->fd);
+  req = mrb_uv_req_current(mrb, b, &ret);
+  mrb_uv_req_check_error(mrb, req, uv_fs_close(
+      mrb_uv_current_loop(mrb), &req->req.fs, context->fd, mrb_nil_p(req->block)? NULL : _uv_fs_cb));
+  if (mrb_nil_p(req->block)) {
+    context->fd = -1;
   }
-  return self;
+  return ret;
 }
 
 static mrb_value
@@ -288,671 +277,389 @@ mrb_uv_fs_write(mrb_state *mrb, mrb_value self)
   mrb_int arg_length = -1;
   mrb_int arg_offset = 0;
   mrb_uv_file* context = (mrb_uv_file*)mrb_uv_get_ptr(mrb, self, &mrb_uv_file_type);
-  mrb_value b = mrb_nil_value();
-  uv_fs_cb fs_cb = _uv_fs_cb;
-  uv_fs_t* req;
-  int r;
+  mrb_value b, ret;
+  mrb_uv_req_t *req;
   uv_buf_t buf;
+  int r;
 
   mrb_get_args(mrb, "&S|ii", &b, &arg_data, &arg_offset, &arg_length);
 
-  if (mrb_nil_p(b)) {
-    fs_cb = NULL;
-  }
-  mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "fs_cb"), b);
-
-  req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
-  memset(req, 0, sizeof(uv_fs_t));
-  req->data = context;
   if (arg_length == -1)
     arg_length = RSTRING_LEN(arg_data);
   if (arg_offset < 0)
     arg_offset = 0;
-  buf.base = RSTRING_PTR(arg_data);
-  buf.len = arg_length;
-  r = uv_fs_write(mrb_uv_current_loop(mrb), req, context->fd, &buf, 1, arg_offset, fs_cb);
-  if (r < 0 || !fs_cb) {
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, r);
-  }
-  return mrb_fixnum_value(r);
+  mrb_str_resize(mrb, arg_data, arg_length);
+
+  req = mrb_uv_req_current(mrb, b, &ret);
+  mrb_uv_req_set_buf(req, &buf, arg_data);
+  mrb_uv_req_check_error(mrb, req, r = uv_fs_write(
+      mrb_uv_current_loop(mrb), &req->req.fs,
+      context->fd, &buf, 1, arg_offset, mrb_nil_p(req->block)? NULL : _uv_fs_cb));
+  return mrb_nil_p(req->block)? mrb_fixnum_value(r) : ret;
 }
 
 static mrb_value
 mrb_uv_fs_read(mrb_state *mrb, mrb_value self)
 {
-  mrb_int arg_length = BUFSIZ;
-  mrb_int arg_offset = 0;
+  mrb_int arg_length = BUFSIZ, arg_offset = 0;
   mrb_uv_file* context = (mrb_uv_file*)mrb_uv_get_ptr(mrb, self, &mrb_uv_file_type);
-  mrb_value b = mrb_nil_value();
-  uv_fs_cb fs_cb = _uv_fs_cb;
+  mrb_value b, buf_str, ret;
   uv_buf_t buf;
-  int len;
-  uv_fs_t* req;
+  mrb_uv_req_t* req;
+  int res;
 
-  mrb_get_args(mrb, "&|i|i", &b, &arg_length, &arg_offset);
+  mrb_get_args(mrb, "&|ii", &b, &arg_length, &arg_offset);
 
-  if (mrb_nil_p(b)) {
-    fs_cb = NULL;
+  buf_str = mrb_str_resize(mrb, mrb_str_new_capa(mrb, arg_length), arg_length);
+  req = mrb_uv_req_current(mrb, b, &ret);
+  mrb_uv_req_set_buf(req, &buf, buf_str);
+  res = uv_fs_read(mrb_uv_current_loop(mrb), &req->req.fs, context->fd,
+                       &buf, 1, arg_offset, mrb_nil_p(req->block)? NULL : _uv_fs_cb);
+  mrb_uv_req_check_error(mrb, req, res);
+  if (mrb_nil_p(req->block)) {
+    mrb_str_resize(mrb, buf_str, res);
+    return buf_str;
   }
-  mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "fs_cb"), b);
-
-  buf.base = mrb_malloc(mrb, arg_length);
-  buf.len = arg_length;
-  req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
-  if (!req) {
-    mrb_free(mrb, buf.base);
-  }
-  memset(req, 0, sizeof(uv_fs_t));
-  req->data = context;
-  len = uv_fs_read(mrb_uv_current_loop(mrb), req, context->fd, &buf, 1, arg_offset, fs_cb);
-  if (len < 0) {
-    mrb_free(mrb, buf.base);
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, len);
-  }
-
-  if (!fs_cb) {
-    mrb_value str = mrb_str_new(mrb, buf.base, len);
-    mrb_free(mrb, buf.base);
-    mrb_uv_fs_req_free(mrb, req);
-    return str;
-  }
-
-  return mrb_nil_value();
+  return ret;
 }
 
 static mrb_value
 mrb_uv_fs_unlink(mrb_state *mrb, mrb_value self)
 {
-  int err;
-  mrb_value arg_path;
-  mrb_value b = mrb_nil_value();
-  uv_fs_cb fs_cb = _uv_fs_cb;
-  static mrb_uv_file context;
-  uv_fs_t* req;
+  char const *arg_path;
+  mrb_value b, ret;
+  mrb_uv_req_t* req;
 
-  mrb_get_args(mrb, "&S", &b, &arg_path);
-  if (mrb_nil_p(b)) {
-    fs_cb = NULL;
-  } else {
-    memset(&context, 0, sizeof(mrb_uv_file));
-    context.mrb = mrb;
-    context.instance = self;
-  }
-  mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "fs_cb"), b);
+  mrb_get_args(mrb, "&z", &b, &arg_path);
 
-  req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
-  memset(req, 0, sizeof(uv_fs_t));
-  req->data = &context;
-  err = uv_fs_unlink(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_path), fs_cb);
-  if (err != 0 || !fs_cb) {
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, err);
-  }
-  return self;
+  req = mrb_uv_req_current(mrb, b, &ret);
+  mrb_uv_req_check_error(mrb, req, uv_fs_unlink(
+      mrb_uv_current_loop(mrb), &req->req.fs, arg_path, mrb_nil_p(req->block)? NULL : _uv_fs_cb));
+
+  return ret;
 }
 
 static mrb_value
 mrb_uv_fs_mkdir(mrb_state *mrb, mrb_value self)
 {
-  int err;
-  mrb_value arg_path = mrb_nil_value();
+  char const *arg_path;
   mrb_int arg_mode = 0755;
-  mrb_value b = mrb_nil_value();
-  uv_fs_cb fs_cb = _uv_fs_cb;
-  static mrb_uv_file context;
-  uv_fs_t* req;
+  mrb_value b, ret;
+  mrb_uv_req_t* req;
 
-  mrb_get_args(mrb, "&S|i", &b, &arg_path, &arg_mode);
-  if (mrb_nil_p(b)) {
-    fs_cb = NULL;
-  } else {
-    memset(&context, 0, sizeof(mrb_uv_file));
-    context.mrb = mrb;
-    context.instance = self;
-  }
-  mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "fs_cb"), b);
-
-  req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
-  memset(req, 0, sizeof(uv_fs_t));
-  req->data = &context;
-  err = uv_fs_mkdir(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_path), arg_mode, fs_cb);
-  if (err != 0 || !fs_cb) {
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, err);
-  }
-  return self;
+  mrb_get_args(mrb, "&z|i", &b, &arg_path, &arg_mode);
+  req = mrb_uv_req_current(mrb, b, &ret);
+  mrb_uv_req_check_error(mrb, req, uv_fs_mkdir(
+      mrb_uv_current_loop(mrb), &req->req.fs, arg_path, arg_mode,
+      mrb_nil_p(req->block)? NULL : _uv_fs_cb));
+  return ret;
 }
 
 static mrb_value
 mrb_uv_fs_rmdir(mrb_state *mrb, mrb_value self)
 {
-  int err;
   mrb_value arg_path;
-  mrb_value b = mrb_nil_value();
-  uv_fs_cb fs_cb = _uv_fs_cb;
-  static mrb_uv_file context;
-  uv_fs_t* req;
+  mrb_value b, ret;
+  mrb_uv_req_t* req;
 
   mrb_get_args(mrb, "&S", &b, &arg_path);
-  if (mrb_nil_p(b)) {
-    fs_cb = NULL;
-  } else {
-    memset(&context, 0, sizeof(mrb_uv_file));
-    context.mrb = mrb;
-    context.instance = self;
-  }
-  mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "fs_cb"), b);
 
-  req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
-  memset(req, 0, sizeof(uv_fs_t));
-  req->data = &context;
-  err = uv_fs_rmdir(mrb_uv_current_loop(mrb), req, mrb_string_value_ptr(mrb, arg_path), fs_cb);
-  if (err != 0 || !fs_cb) {
-    mrb_uv_fs_free(mrb, req);
-    mrb_uv_check_error(mrb, err);
-  }
-  return self;
+  req = mrb_uv_req_current(mrb, b, &ret);
+  mrb_uv_req_check_error(mrb, req, uv_fs_rmdir(
+      mrb_uv_current_loop(mrb), &req->req.fs, mrb_string_value_ptr(mrb, arg_path),
+      mrb_nil_p(req->block)? NULL : _uv_fs_cb));
+  return ret;
 }
 
 static mrb_value
 mrb_uv_fs_scandir(mrb_state *mrb, mrb_value self)
 {
-  int err;
-  mrb_value arg_path;
+  char const *arg_path;
   mrb_int arg_flags;
-  mrb_value b = mrb_nil_value();
-  static mrb_uv_file context;
-  uv_fs_t* req;
+  mrb_value b, ret;
+  mrb_uv_req_t* req;
+  int res;
 
-  mrb_get_args(mrb, "&Si", &b, &arg_path, &arg_flags);
-  if (!mrb_nil_p(b)) {
-    context.mrb = mrb;
-    context.instance = self;
-    mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "fs_cb"), b);
-  }
+  mrb_get_args(mrb, "&zi", &b, &arg_path, &arg_flags);
+  req = mrb_uv_req_current(mrb, b, &ret);
+  res = uv_fs_scandir(mrb_uv_current_loop(mrb), &req->req.fs, arg_path, arg_flags,
+                      mrb_nil_p(req->block)? NULL : _uv_fs_cb);
 
-  req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
-  req->data = &context;
-  err = uv_fs_scandir(mrb_uv_current_loop(mrb), req, mrb_string_value_ptr(mrb, arg_path),
-                      arg_flags, mrb_nil_p(b)? NULL : _uv_fs_cb);
-  if (err < 0) {
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, err);
-  }
-  if (mrb_nil_p(b)) {
-    mrb_value const ret = mrb_ary_new_capa(mrb, req->result);
-    uv_dirent_t ent;
-    while (uv_fs_scandir_next(req, &ent) != UV_EOF) {
-      mrb_ary_push(mrb, ret, mrb_assoc_new(mrb, mrb_str_new_cstr(mrb, ent.name), dirtype_to_sym(mrb, ent.type)));
-    }
-    mrb_uv_fs_req_free(mrb, req);
+  if (mrb_nil_p(req->block) && res >= 0) {
+    mrb_value ret = dir_to_array(mrb, &req->req.fs);
+    mrb_uv_req_clear(req);
     return ret;
   }
-  return self;
+  mrb_uv_req_check_error(mrb, req, res);
+  return ret;
 }
 
 static mrb_value
 mrb_uv_fs_stat(mrb_state *mrb, mrb_value self)
 {
-  int err;
-  mrb_value arg_path;
-  mrb_value b = mrb_nil_value();
-  uv_fs_cb fs_cb = _uv_fs_cb;
-  static mrb_uv_file context;
-  uv_fs_t* req;
+  char const *arg_path;
+  mrb_value b, ret;
+  mrb_uv_req_t* req;
+  int res;
 
-  mrb_get_args(mrb, "&S", &b, &arg_path);
-  if (mrb_nil_p(b)) {
-    fs_cb = NULL;
-  } else {
-    memset(&context, 0, sizeof(mrb_uv_file));
-    context.mrb = mrb;
-    context.instance = self;
-  }
-  mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "fs_cb"), b);
+  mrb_get_args(mrb, "&z", &b, &arg_path);
 
-  req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
-  memset(req, 0, sizeof(uv_fs_t));
-  req->data = &context;
-  err = uv_fs_stat(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_path), fs_cb);
-  if (err != 0) {
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, err);
-  }
+  req = mrb_uv_req_current(mrb, b, &ret);
+  res = uv_fs_stat(mrb_uv_current_loop(mrb), &req->req.fs, arg_path,
+                   mrb_nil_p(req->block)? NULL : _uv_fs_cb);
 
-  if (mrb_nil_p(b)) {
-    mrb_value ret = mrb_uv_create_stat(mrb, &req->statbuf);
-    mrb_uv_fs_req_free(mrb, req);
+  if (mrb_nil_p(req->block) && res >= 0) {
+    mrb_value ret = mrb_uv_create_stat(mrb, &req->req.fs.statbuf);
+    mrb_uv_req_clear(req);
     return ret;
   }
-  return self;
+  mrb_uv_req_check_error(mrb, req, res);
+  return ret;
 }
 
 static mrb_value
 mrb_uv_fs_fstat(mrb_state *mrb, mrb_value self)
 {
-  int err;
-  mrb_value b = mrb_nil_value();
-  uv_fs_cb fs_cb = _uv_fs_cb;
-  mrb_uv_file *context;
-  uv_fs_t* req;
+  mrb_value b, ret;
+  mrb_uv_req_t* req;
+  mrb_uv_file *context = (mrb_uv_file*)mrb_uv_get_ptr(mrb, self, &mrb_uv_file_type);
+  int res;
 
   mrb_get_args(mrb, "&", &b);
-  if (mrb_nil_p(b)) {
-    fs_cb = NULL;
-  }
-  mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "fs_cb"), b);
 
-  context = (mrb_uv_file*)mrb_uv_get_ptr(mrb, self, &mrb_uv_file_type);
-  req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
-  memset(req, 0, sizeof(uv_fs_t));
-  req->data = &context;
-  err = uv_fs_fstat(mrb_uv_current_loop(mrb), req, context->fd, fs_cb);
-  if (err != 0) {
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, err);
-  }
+  req = mrb_uv_req_current(mrb, b, &ret);
+  res = uv_fs_fstat(mrb_uv_current_loop(mrb), &req->req.fs, context->fd,
+                    mrb_nil_p(req->block)? NULL : _uv_fs_cb);
 
-  if (mrb_nil_p(b)) {
-    mrb_value ret = mrb_uv_create_stat(mrb, &req->statbuf);
-    mrb_uv_fs_req_free(mrb, req);
+  if (mrb_nil_p(req->block) && res >= 0) {
+    mrb_value ret = mrb_uv_create_stat(mrb, &req->req.fs.statbuf);
+    mrb_uv_req_clear(req);
     return ret;
   }
-  return self;
+  mrb_uv_req_check_error(mrb, req, res);
+  return ret;
 }
 
 static mrb_value
 mrb_uv_fs_lstat(mrb_state *mrb, mrb_value self)
 {
-  int err;
-  mrb_value arg_path;
-  mrb_value b = mrb_nil_value();
-  uv_fs_cb fs_cb = _uv_fs_cb;
-  static mrb_uv_file context;
-  uv_fs_t* req;
+  char const *arg_path;
+  mrb_value b, ret;
+  mrb_uv_req_t* req;
+  int res;
 
-  mrb_get_args(mrb, "&S", &b, &arg_path);
-  if (mrb_nil_p(b)) {
-    fs_cb = NULL;
-  } else {
-    memset(&context, 0, sizeof(mrb_uv_file));
-    context.mrb = mrb;
-    context.instance = self;
-  }
-  mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "fs_cb"), b);
+  mrb_get_args(mrb, "&z", &b, &arg_path);
 
-  req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
-  memset(req, 0, sizeof(uv_fs_t));
-  req->data = &context;
-  err = uv_fs_lstat(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_path), fs_cb);
-  if (err != 0) {
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, err);
-  }
-
-  if (mrb_nil_p(b)) {
-    mrb_value ret = mrb_uv_create_stat(mrb, &req->statbuf);
-    mrb_uv_fs_req_free(mrb, req);
+  req = mrb_uv_req_current(mrb, b, &ret);
+  res = uv_fs_lstat(mrb_uv_current_loop(mrb), &req->req.fs, arg_path,
+                    mrb_nil_p(req->block)? NULL : _uv_fs_cb);
+  if (mrb_nil_p(req->block) && res >= 0) {
+    mrb_value ret = mrb_uv_create_stat(mrb, &req->req.fs.statbuf);
+    mrb_uv_req_clear(req);
     return ret;
   }
-  return self;
+  mrb_uv_req_check_error(mrb, req, res);
+  return ret;
 }
 
 static mrb_value
 mrb_uv_fs_rename(mrb_state *mrb, mrb_value self)
 {
-  int err;
-  mrb_value arg_path, arg_new_path;
-  mrb_value b = mrb_nil_value();
-  uv_fs_cb fs_cb = _uv_fs_cb;
-  static mrb_uv_file context;
-  uv_fs_t* req;
+  char const *arg_path, *arg_new_path;
+  mrb_value b, ret;
+  mrb_uv_req_t* req;
 
-  mrb_get_args(mrb, "&SS", &b, &arg_path, &arg_new_path);
-  if (mrb_nil_p(b)) {
-    fs_cb = NULL;
-  } else {
-    memset(&context, 0, sizeof(mrb_uv_file));
-    context.mrb = mrb;
-    context.instance = self;
-  }
-  mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "fs_cb"), b);
+  mrb_get_args(mrb, "&zz", &b, &arg_path, &arg_new_path);
 
-  req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
-  memset(req, 0, sizeof(uv_fs_t));
-  req->data = &context;
-  err = uv_fs_rename(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_path), RSTRING_PTR(arg_new_path), fs_cb);
-  if (err != 0) {
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, err);
-  }
-  return self;
+  req = mrb_uv_req_current(mrb, b, &ret);
+  mrb_uv_req_check_error(mrb, req, uv_fs_rename(
+      mrb_uv_current_loop(mrb), &req->req.fs, arg_path, arg_new_path, mrb_nil_p(req->block)? NULL : _uv_fs_cb));
+  return ret;
 }
 
 static mrb_value
 mrb_uv_fs_fsync(mrb_state *mrb, mrb_value self)
 {
-  int err;
-  mrb_value b = mrb_nil_value();
-  uv_fs_cb fs_cb = _uv_fs_cb;
-  mrb_uv_file *context;
-  uv_fs_t* req;
+  mrb_value b, ret;
+  mrb_uv_file *context = (mrb_uv_file*)mrb_uv_get_ptr(mrb, self, &mrb_uv_file_type);
+  mrb_uv_req_t* req;
 
   mrb_get_args(mrb, "&", &b);
-  if (mrb_nil_p(b)) {
-    fs_cb = NULL;
-  }
-  mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "fs_cb"), b);
 
-  context = (mrb_uv_file*)mrb_uv_get_ptr(mrb, self, &mrb_uv_file_type);
-  req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
-  memset(req, 0, sizeof(uv_fs_t));
-  req->data = &context;
-  err = uv_fs_fsync(mrb_uv_current_loop(mrb), req, context->fd, fs_cb);
-  if (err != 0) {
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, err);
-  }
-  return self;
+  req = mrb_uv_req_current(mrb, b, &ret);
+  mrb_uv_req_check_error(mrb, req, uv_fs_fsync(
+      mrb_uv_current_loop(mrb), &req->req.fs, context->fd, mrb_nil_p(req->block)? NULL : _uv_fs_cb));
+  return ret;
 }
 
 static mrb_value
 mrb_uv_fs_fdatasync(mrb_state *mrb, mrb_value self)
 {
-  int err;
-  mrb_value b = mrb_nil_value();
-  uv_fs_cb fs_cb = _uv_fs_cb;
-  mrb_uv_file *context;
-  uv_fs_t* req;
+  mrb_value b, ret;
+  mrb_uv_file *context = (mrb_uv_file*)mrb_uv_get_ptr(mrb, self, &mrb_uv_file_type);
+  mrb_uv_req_t* req;
 
   mrb_get_args(mrb, "&", &b);
-  if (mrb_nil_p(b)) {
-    fs_cb = NULL;
-  }
-  mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "fs_cb"), b);
 
-  context = (mrb_uv_file*)mrb_uv_get_ptr(mrb, self, &mrb_uv_file_type);
-  req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
-  memset(req, 0, sizeof(uv_fs_t));
-  req->data = &context;
-  err = uv_fs_fdatasync(mrb_uv_current_loop(mrb), req, context->fd, fs_cb);
-  if (err != 0) {
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, err);
-  }
-  return self;
+  req = mrb_uv_req_current(mrb, b, &ret);
+  mrb_uv_req_check_error(mrb, req, uv_fs_fdatasync(
+      mrb_uv_current_loop(mrb), &req->req.fs, context->fd, mrb_nil_p(req->block)? NULL : _uv_fs_cb));
+  return ret;
 }
 
 static mrb_value
 mrb_uv_fs_ftruncate(mrb_state *mrb, mrb_value self)
 {
-  int err;
   mrb_int arg_offset;
-  mrb_value b = mrb_nil_value();
-  uv_fs_cb fs_cb = _uv_fs_cb;
-  mrb_uv_file *context;
-  uv_fs_t* req;
+  mrb_value b, ret;
+  mrb_uv_file *context = (mrb_uv_file*)mrb_uv_get_ptr(mrb, self, &mrb_uv_file_type);
+  mrb_uv_req_t* req;
 
   mrb_get_args(mrb, "&i", &b, &arg_offset);
-  if (mrb_nil_p(b)) {
-    fs_cb = NULL;
-  }
-  mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "fs_cb"), b);
 
-  context = (mrb_uv_file*)mrb_uv_get_ptr(mrb, self, &mrb_uv_file_type);
-  req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
-  memset(req, 0, sizeof(uv_fs_t));
-  req->data = &context;
-  err = uv_fs_ftruncate(mrb_uv_current_loop(mrb), req, context->fd, arg_offset, fs_cb);
-  if (err != 0) {
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, err);
-  }
-  return self;
+  req = mrb_uv_req_current(mrb, b, &ret);
+  mrb_uv_req_check_error(mrb, req, uv_fs_ftruncate(
+      mrb_uv_current_loop(mrb), &req->req.fs, context->fd, arg_offset,
+      mrb_nil_p(req->block)? NULL : _uv_fs_cb));
+  return ret;
 }
 
 static mrb_value
 mrb_uv_fs_sendfile(mrb_state *mrb, mrb_value self)
 {
-  int err;
   mrb_int arg_outfd, arg_infd, arg_offset, arg_length;
-  mrb_value b = mrb_nil_value(), outfile, infile;
-  uv_fs_cb fs_cb = _uv_fs_cb;
-  static mrb_uv_file context;
-  uv_fs_t* req;
+  mrb_value b, outfile, infile, ret;
+  mrb_uv_req_t* req;
 
   mrb_get_args(mrb, "&ooii", &b, &infile, &outfile, &arg_offset, &arg_length);
   arg_infd = mrb_uv_to_fd(mrb, infile);
   arg_outfd = mrb_uv_to_fd(mrb, outfile);
-  if (mrb_nil_p(b)) {
-    fs_cb = NULL;
-  } else {
-    memset(&context, 0, sizeof(mrb_uv_file));
-    context.mrb = mrb;
-    context.instance = self;
-  }
-  mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "fs_cb"), b);
 
-  req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
-  memset(req, 0, sizeof(uv_fs_t));
-  req->data = &context;
-  err = uv_fs_sendfile(mrb_uv_current_loop(mrb), req, arg_infd, arg_outfd, arg_offset, arg_length, fs_cb);
-  if (err != 0) {
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, err);
-  }
-  return self;
+  req = mrb_uv_req_current(mrb, b, &ret);
+  mrb_uv_req_check_error(mrb, req, uv_fs_sendfile(
+      mrb_uv_current_loop(mrb), &req->req.fs, arg_infd, arg_outfd, arg_offset, arg_length,
+      mrb_nil_p(req->block)? NULL : _uv_fs_cb));
+  return ret;
 }
 
 static mrb_value
 mrb_uv_fs_chmod(mrb_state *mrb, mrb_value self)
 {
-  int err;
-  mrb_value arg_path;
+  char const *arg_path;
   mrb_int arg_mode;
-  mrb_value b = mrb_nil_value();
-  uv_fs_cb fs_cb = _uv_fs_cb;
-  static mrb_uv_file context;
-  uv_fs_t* req;
+  mrb_value b, ret;
+  mrb_uv_req_t* req;
 
-  mrb_get_args(mrb, "&Si", &b, &arg_path, &arg_mode);
-  if (mrb_nil_p(b)) {
-    fs_cb = NULL;
-  } else {
-    memset(&context, 0, sizeof(mrb_uv_file));
-    context.mrb = mrb;
-    context.instance = self;
-  }
-  mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "fs_cb"), b);
+  mrb_get_args(mrb, "&zi", &b, &arg_path, &arg_mode);
 
-  req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
-  memset(req, 0, sizeof(uv_fs_t));
-  req->data = &context;
-  err = uv_fs_chmod(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_path), arg_mode, fs_cb);
-  if (err != 0) {
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, err);
-  }
-  return self;
+  req = mrb_uv_req_current(mrb, b, &ret);
+  mrb_uv_req_check_error(mrb, req, uv_fs_chmod(
+      mrb_uv_current_loop(mrb), &req->req.fs, arg_path, arg_mode, mrb_nil_p(req->block)? NULL : _uv_fs_cb));
+  return ret;
 }
 
 static mrb_value
 mrb_uv_fs_link(mrb_state *mrb, mrb_value self)
 {
-  int err;
-  mrb_value arg_path, arg_new_path;
-  mrb_value b = mrb_nil_value();
-  uv_fs_cb fs_cb = _uv_fs_cb;
-  static mrb_uv_file context;
-  uv_fs_t* req;
+  char const *arg_path, *arg_new_path;
+  mrb_value b, ret;
+  mrb_uv_req_t* req;
 
-  mrb_get_args(mrb, "&SS", &b, &arg_path, &arg_new_path);
-  if (mrb_nil_p(b)) {
-    fs_cb = NULL;
-  } else {
-    memset(&context, 0, sizeof(mrb_uv_file));
-    context.mrb = mrb;
-    context.instance = self;
-  }
-  mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "fs_cb"), b);
+  mrb_get_args(mrb, "&zz", &b, &arg_path, &arg_new_path);
 
-  req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
-  memset(req, 0, sizeof(uv_fs_t));
-  req->data = &context;
-  err = uv_fs_link(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_path), RSTRING_PTR(arg_new_path), fs_cb);
-  if (err != 0) {
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, err);
-  }
-  return self;
+  req = mrb_uv_req_current(mrb, b, &ret);
+  mrb_uv_req_check_error(mrb, req, uv_fs_link(
+      mrb_uv_current_loop(mrb), &req->req.fs, arg_path, arg_new_path, mrb_nil_p(req->block)? NULL : _uv_fs_cb));
+  return ret;
 }
 
 static mrb_value
 mrb_uv_fs_utime(mrb_state *mrb, mrb_value self)
 {
-  char *path;
-  mrb_value b;
-  static mrb_uv_file context;
-  uv_fs_t *req;
+  char const *path;
   mrb_float atime, mtime;
-  int err;
+  mrb_value b, ret;
+  mrb_uv_req_t* req;
 
   mrb_get_args(mrb, "&zff", &b, &path, &atime, &mtime);
 
-  if (!mrb_nil_p(b)) {
-    mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "fs_cb"), b);
-    context.mrb = mrb;
-    context.instance = self;
-    context.fd = -1;
-  }
-
-  req = (uv_fs_t*)mrb_malloc(mrb, sizeof(uv_fs_t));
-  req->data = &context;
-  err = uv_fs_utime(mrb_uv_current_loop(mrb), req, path, (double)atime, (double)mtime, mrb_nil_p(b)? NULL : _uv_fs_cb);
-  if (err < 0 || mrb_nil_p(b)) {
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, err);
-  }
-  return self;
+  req = mrb_uv_req_current(mrb, b, &ret);
+  mrb_uv_req_check_error(mrb, req, uv_fs_utime(
+      mrb_uv_current_loop(mrb), &req->req.fs, path, (double)atime, (double)mtime,
+      mrb_nil_p(req->block)? NULL : _uv_fs_cb));
+  return ret;
 }
 
 static mrb_value
 mrb_uv_fs_futime(mrb_state *mrb, mrb_value self)
 {
   mrb_float atime, mtime;
-  mrb_value b;
-  mrb_uv_file *ctx;
-  uv_fs_t *req;
-  int err;
+  mrb_value b, ret;
+  mrb_uv_file *ctx = (mrb_uv_file*)mrb_uv_get_ptr(mrb, self, &mrb_uv_file_type);
+  mrb_uv_req_t *req;
 
   mrb_get_args(mrb, "&ff", &b, &atime, &mtime);
 
-  if (!mrb_nil_p(b)) {
-    mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "fs_cb"), b);
-  }
-
-  ctx = (mrb_uv_file*)mrb_uv_get_ptr(mrb, self, &mrb_uv_file_type);
-  req = (uv_fs_t*)mrb_malloc(mrb, sizeof(uv_fs_t));
-  req->data = ctx;
-  err = uv_fs_futime(mrb_uv_current_loop(mrb), req, ctx->fd, (double)atime, (double)mtime, mrb_nil_p(b)? NULL : _uv_fs_cb);
-  if (err < 0 || mrb_nil_p(b)) {
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, err);
-  }
-  return self;
+  req = mrb_uv_req_current(mrb, b, &ret);
+  mrb_uv_req_check_error(mrb, req, uv_fs_futime(
+      mrb_uv_current_loop(mrb), &req->req.fs, ctx->fd,
+      (double)atime, (double)mtime, mrb_nil_p(req->block)? NULL : _uv_fs_cb));
+  return ret;
 }
 
 static mrb_value
 mrb_uv_fs_fchmod(mrb_state *mrb, mrb_value self)
 {
   mrb_int mode;
-  mrb_value b;
-  mrb_uv_file *ctx;
-  uv_fs_t *req;
-  int err;
+  mrb_value b, ret;
+  mrb_uv_file *ctx = (mrb_uv_file*)mrb_uv_get_ptr(mrb, self, &mrb_uv_file_type);
+  mrb_uv_req_t *req;
 
   mrb_get_args(mrb, "&i", &b, &mode);
 
-  if (!mrb_nil_p(b)) {
-    mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "fs_cb"), b);
-  }
-
-  ctx = (mrb_uv_file*)mrb_uv_get_ptr(mrb, self, &mrb_uv_file_type);
-  req = (uv_fs_t*)mrb_malloc(mrb, sizeof(uv_fs_t));
-  req->data = ctx;
-  err = uv_fs_fchmod(mrb_uv_current_loop(mrb), req, ctx->fd, mode, mrb_nil_p(b)? NULL : _uv_fs_cb);
-  if (err < 0 || mrb_nil_p(b)) {
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, err);
-  }
-
-  return self;
+  req = mrb_uv_req_current(mrb, b, &ret);
+  mrb_uv_req_check_error(mrb, req, uv_fs_fchmod(
+      mrb_uv_current_loop(mrb), &req->req.fs, ctx->fd, mode, mrb_nil_p(req->block)? NULL : _uv_fs_cb));
+  return ret;
 }
 
 static mrb_value
 mrb_uv_fs_symlink(mrb_state *mrb, mrb_value self)
 {
-  char *path, *new_path;
+  char const *path, *new_path;
   mrb_int flags = 0;
-  mrb_value b;
-  uv_fs_t *req;
-  int err;
-  static mrb_uv_file ctx;
+  mrb_value b, ret;
+  mrb_uv_req_t *req;
 
   mrb_get_args(mrb, "&zz|i", &b, &path, &new_path, &flags);
 
-  if (!mrb_nil_p(b)) {
-    mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "fs_cb"), b);
-    ctx.mrb = mrb;
-    ctx.instance = self;
-    ctx.fd = -1;
-  }
-
-  req = (uv_fs_t*)mrb_malloc(mrb, sizeof(uv_fs_t));
-  req->data = &ctx;
-  err = uv_fs_symlink(mrb_uv_current_loop(mrb), req, path, new_path, flags, mrb_nil_p(b)? NULL : _uv_fs_cb);
-  if (err < 0 || mrb_nil_p(b)) {
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, err);
-  }
-
-  return self;
+  req = mrb_uv_req_current(mrb, b, &ret);
+  mrb_uv_req_check_error(mrb, req, uv_fs_symlink(
+      mrb_uv_current_loop(mrb), &req->req.fs, path, new_path, flags, mrb_nil_p(req->block)? NULL : _uv_fs_cb));
+  return ret;
 }
 
 static mrb_value
 mrb_uv_fs_readlink(mrb_state *mrb, mrb_value self)
 {
-  char *path;
-  mrb_value b;
-  static mrb_uv_file ctx;
-  uv_fs_t *req;
-  int err;
+  char const *path;
+  mrb_value b, ret;
+  mrb_uv_req_t *req;
+  int res;
 
   mrb_get_args(mrb, "&z", &b, &path);
 
-  if (!mrb_nil_p(b)) {
-    mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "fs_cb"), b);
-    ctx.mrb = mrb;
-    ctx.instance = self;
-    ctx.fd = -1;
-  }
+  req = mrb_uv_req_current(mrb, b, &ret);
+  res = uv_fs_readlink(
+      mrb_uv_current_loop(mrb), &req->req.fs, path, mrb_nil_p(req->block)? NULL : _uv_fs_cb);
 
-  req = (uv_fs_t*)mrb_malloc(mrb, sizeof(uv_fs_t));
-  req->data = &ctx;
-  err = uv_fs_readlink(mrb_uv_current_loop(mrb), req, path, mrb_nil_p(b)? NULL : _uv_fs_cb);
-  if (err < 0) {
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, err);
-  }
-
-  if (mrb_nil_p(b)) {
-    mrb_value const ret = mrb_str_new_cstr(mrb, req->ptr);
-    mrb_uv_fs_req_free(mrb, req);
+  if (mrb_nil_p(req->block) && res >= 0) {
+    mrb_value const ret = mrb_str_new_cstr(mrb, req->req.fs.ptr);
+    mrb_uv_req_clear(req);
     return ret;
   }
-  return self;
+  mrb_uv_req_check_error(mrb, req, res);
+  return ret;
 }
 
 #if MRB_UV_CHECK_VERSION(1, 8, 0)
@@ -960,35 +667,24 @@ mrb_uv_fs_readlink(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_uv_fs_realpath(mrb_state *mrb, mrb_value self)
 {
-  char *path;
-  mrb_value b;
-  static mrb_uv_file ctx;
-  uv_fs_t *req;
-  int err;
+  char const *path;
+  mrb_value b, ret;
+  mrb_uv_req_t *req;
+  int res;
 
   mrb_get_args(mrb, "&z", &b, &path);
 
-  if (!mrb_nil_p(b)) {
-    mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "fs_cb"), b);
-    ctx.mrb = mrb;
-    ctx.instance = self;
-    ctx.fd = -1;
-  }
+  req = mrb_uv_req_current(mrb, b, &ret);
+  res = uv_fs_realpath(mrb_uv_current_loop(mrb), &req->req.fs, path,
+                       mrb_nil_p(req->block)? NULL : _uv_fs_cb);
 
-  req = (uv_fs_t*)mrb_malloc(mrb, sizeof(uv_fs_t));
-  req->data = &ctx;
-  err = uv_fs_realpath(mrb_uv_current_loop(mrb), req, path, mrb_nil_p(b)? NULL : _uv_fs_cb);
-  if (err < 0) {
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, err);
-  }
-
-  if (mrb_nil_p(b)) {
-    mrb_value const ret = mrb_str_new_cstr(mrb, req->ptr);
-    mrb_uv_fs_req_free(mrb, req);
+  if (mrb_nil_p(req->block)) {
+    mrb_value const ret = mrb_str_new_cstr(mrb, req->req.fs.ptr);
+    mrb_uv_req_clear(req);
     return ret;
   }
-  return self;
+  mrb_uv_req_check_error(mrb, req, res);
+  return ret;
 }
 
 #endif
@@ -996,107 +692,58 @@ mrb_uv_fs_realpath(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_uv_fs_chown(mrb_state *mrb, mrb_value self)
 {
-  char *path;
+  char const *path;
   mrb_int uid, gid;
-  mrb_value b;
-  uv_fs_t *req;
-  int err;
-  static mrb_uv_file ctx;
+  mrb_value b, ret;
+  mrb_uv_req_t *req;
 
   mrb_get_args(mrb, "&zii", &b, &path, &uid, &gid);
 
-  req = (uv_fs_t*)mrb_malloc(mrb, sizeof(uv_fs_t));
-  req->data = &ctx;
-  err = uv_fs_chown(mrb_uv_current_loop(mrb), req, path, (uv_uid_t)uid, (uv_gid_t)gid, mrb_nil_p(b)? NULL : _uv_fs_cb);
-  if (err < 0 || mrb_nil_p(b)) {
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, err);
-  }
-
-  return self;
+  req = mrb_uv_req_current(mrb, b, &ret);
+  mrb_uv_req_check_error(mrb, req, uv_fs_chown(
+      mrb_uv_current_loop(mrb), &req->req.fs, path,
+      (uv_uid_t)uid, (uv_gid_t)gid, mrb_nil_p(req->block)? NULL : _uv_fs_cb));
+  return ret;
 }
 
 static mrb_value
 mrb_uv_fs_fchown(mrb_state *mrb, mrb_value self)
 {
   mrb_int uid, gid;
-  mrb_value b;
-  mrb_uv_file *ctx;
-  uv_fs_t *req;
-  int err;
+  mrb_value b, ret;
+  mrb_uv_file *ctx = (mrb_uv_file*)mrb_uv_get_ptr(mrb, self, &mrb_uv_file_type);
+  mrb_uv_req_t *req;
 
   mrb_get_args(mrb, "&ii", &b, &uid, &gid);
 
-  ctx = (mrb_uv_file*)mrb_uv_get_ptr(mrb, self, &mrb_uv_file_type);
-  req = (uv_fs_t*)mrb_malloc(mrb, sizeof(uv_fs_t));
-  req->data = ctx;
-  err = uv_fs_fchown(mrb_uv_current_loop(mrb), req, ctx->fd, (uv_uid_t)uid, (uv_gid_t)gid, mrb_nil_p(b)? NULL : _uv_fs_cb);
-  if (err < 0 || mrb_nil_p(b)) {
-    mrb_uv_fs_req_free(mrb, req);
-    mrb_uv_check_error(mrb, err);
-  }
-
-  return self;
-}
-
-static void
-fs_req_cb(uv_fs_t *req)
-{
-  mrb_uv_req_t *req_data = (mrb_uv_req_t*)req->data;
-  mrb_state *mrb = req_data->mrb;
-  mrb_value b = req_data->block;
-  ssize_t res = req->result;
-
-  switch (req->fs_type) {
-  case UV_FS_MKDTEMP: {
-    mrb_value args[] = { mrb_str_new_cstr(mrb, req->path) };
-
-    mrb_uv_req_release(mrb, req_data->instance);
-    mrb_uv_check_error(mrb, res);
-    mrb_yield_argv(mrb, b, 1, args);
-  } break;
-
-  case UV_FS_ACCESS: {
-    mrb_value args[2] = { mrb_bool_value(req->result == 0), mrb_nil_value() };
-    if (req->result) {
-      args[1] = mrb_symbol_value(mrb_intern_cstr(mrb, uv_err_name(req->result)));
-    }
-    mrb_uv_req_release(mrb, req_data->instance);
-    mrb_yield_argv(mrb, b, 2, args);
-  } break;
-
-#if MRB_UV_CHECK_VERSION(1, 14, 0)
-  case UV_FS_COPYFILE: {
-    mrb_uv_req_release(mrb, req_data->instance);
-    mrb_uv_check_error(mrb, res);
-    mrb_yield_argv(mrb, b, 0, NULL);
-  } break;
-#endif
-
-  default: mrb_assert(FALSE);
-  }
+  req = mrb_uv_req_current(mrb, b, &ret);
+  mrb_uv_req_check_error(mrb, req, uv_fs_fchown(
+      mrb_uv_current_loop(mrb), &req->req.fs, ctx->fd,
+      (uv_uid_t)uid, (uv_gid_t)gid, mrb_nil_p(req->block)? NULL : _uv_fs_cb));
+  return ret;
 }
 
 static mrb_value
 mrb_uv_fs_mkdtemp(mrb_state *mrb, mrb_value self)
 {
-  char *tmp;
-  mrb_value proc;
+  char const *tmp;
+  mrb_value b, ret;
+  mrb_uv_req_t *req;
+  int res;
 
-  mrb_get_args(mrb, "&z", &proc, &tmp);
-  if (mrb_nil_p(proc)) {
-    uv_fs_t req;
-    mrb_value ret;
-    mrb_uv_check_error(mrb, uv_fs_mkdtemp(mrb_uv_current_loop(mrb), &req, tmp, NULL));
-    ret = mrb_str_new_cstr(mrb, req.path);
-    uv_fs_req_cleanup(&req);
+  mrb_get_args(mrb, "&z", &b, &tmp);
+
+  req = mrb_uv_req_current(mrb, b, &ret);
+  res = uv_fs_mkdtemp(mrb_uv_current_loop(mrb), &req->req.fs,
+                      tmp, mrb_nil_p(req->block)? NULL : _uv_fs_cb);
+
+  if (mrb_nil_p(req->block) && res >= 0) {
+    mrb_value const ret = mrb_str_new_cstr(mrb, req->req.fs.path);
+    mrb_uv_req_clear(req);
     return ret;
-  } else {
-    mrb_value req_val = mrb_uv_req_alloc(mrb, UV_FS, proc);
-    mrb_uv_req_t *req = (mrb_uv_req_t*)DATA_PTR(req_val);
-    mrb_uv_check_error(mrb, uv_fs_mkdtemp(mrb_uv_current_loop(mrb), (uv_fs_t*)&req->req, tmp, fs_req_cb));
-    return req_val;
   }
+  mrb_uv_req_check_error(mrb, req, res);
+  return ret;
 }
 
 static mrb_value
@@ -1104,31 +751,21 @@ mrb_uv_fs_access(mrb_state *mrb, mrb_value self)
 {
   const char *path;
   mrb_int flags;
-  mrb_value proc;
+  int res;
+  mrb_value b, ret;
+  mrb_uv_req_t *req;
 
-  mrb_get_args(mrb, "&zi", &proc, &path, &flags);
-  if (mrb_nil_p(proc)) {
-    uv_fs_t req;
-    int res;
+  mrb_get_args(mrb, "&zi", &b, &path, &flags);
 
-    res = uv_fs_access(mrb_uv_current_loop(mrb), &req, path, flags, NULL);
-    switch(res) {
-    case 0: return mrb_true_value();
-    case UV_EPERM: return mrb_false_value();
-    case UV_ENOENT:
-      if (req.flags == F_OK) {
-        return mrb_false_value();
-      }
-    default:
-      mrb_uv_check_error(mrb, res);
-      return mrb_nil_value();
-    }
-  } else {
-    mrb_value req_val = mrb_uv_req_alloc(mrb, UV_FS, proc);
-    mrb_uv_req_t *req = (mrb_uv_req_t*)DATA_PTR(req_val);
-    mrb_uv_check_error(mrb, uv_fs_access(mrb_uv_current_loop(mrb), (uv_fs_t*)&req->req, path, flags, fs_req_cb));
-    return req_val;
+  req = mrb_uv_req_current(mrb, b, &ret);
+  res = uv_fs_access(mrb_uv_current_loop(mrb), &req->req.fs, path, flags,
+                     mrb_nil_p(req->block)? NULL : _uv_fs_cb);
+  if (mrb_nil_p(req->block)) {
+    mrb_uv_req_clear(req);
+    return mrb_uv_create_status(mrb, res);
   }
+  mrb_uv_req_check_error(mrb, req, res);
+  return ret;
 }
 
 #if MRB_UV_CHECK_VERSION(1, 14, 0)
@@ -1138,19 +775,13 @@ mrb_uv_fs_copyfile(mrb_state *mrb, mrb_value self)
 {
   const char *old_path, *new_path;
   mrb_int flags = 0;
-  mrb_value proc;
+  mrb_value proc, ret;
+  mrb_uv_req_t *req;
 
   mrb_get_args(mrb, "&zz|i", &proc, &old_path, &new_path, &flags);
-  if (mrb_nil_p(proc)) {
-    uv_fs_t req;
-    mrb_uv_check_error(mrb, uv_fs_copyfile(mrb_uv_current_loop(mrb), &req, old_path, new_path, flags, NULL));
-    return mrb_nil_value();
-  } else {
-    mrb_value req_val = mrb_uv_req_alloc(mrb, UV_FS, proc);
-    mrb_uv_req_t *req = (mrb_uv_req_t*)DATA_PTR(req_val);
-    mrb_uv_check_error(mrb, uv_fs_copyfile(mrb_uv_current_loop(mrb), (uv_fs_t*)&req->req, old_path, new_path, flags, fs_req_cb));
-    return req_val;
-  }
+  req = mrb_uv_req_current(mrb, proc, &ret);
+  mrb_uv_req_check_error(mrb, req, uv_fs_copyfile(mrb_uv_current_loop(mrb), &req->req.fs, old_path, new_path, flags, NULL));
+  return ret;
 }
 
 #endif

--- a/src/fs.c
+++ b/src/fs.c
@@ -166,7 +166,9 @@ _uv_fs_cb(uv_fs_t* req)
     }
     break;
 
+#if MRB_UV_CHECK_VERSION(1, 8, 0)
   case UV_FS_REALPATH:
+#endif
   case UV_FS_READLINK: {
     mrb_value res;
     mrb_assert(!mrb_nil_p(proc));
@@ -965,6 +967,8 @@ mrb_uv_fs_readlink(mrb_state *mrb, mrb_value self)
   return self;
 }
 
+#if MRB_UV_CHECK_VERSION(1, 8, 0)
+
 static mrb_value
 mrb_uv_fs_realpath(mrb_state *mrb, mrb_value self)
 {
@@ -998,6 +1002,8 @@ mrb_uv_fs_realpath(mrb_state *mrb, mrb_value self)
   }
   return self;
 }
+
+#endif
 
 static mrb_value
 mrb_uv_fs_chown(mrb_state *mrb, mrb_value self)
@@ -1077,11 +1083,13 @@ fs_req_cb(uv_fs_t *req)
     mrb_yield_argv(mrb, b, 2, args);
   } break;
 
+#if MRB_UV_CHECK_VERSION(1, 14, 0)
   case UV_FS_COPYFILE: {
     mrb_uv_req_release(mrb, req_data->instance);
     mrb_uv_check_error(mrb, res);
     mrb_yield_argv(mrb, b, 0, NULL);
   } break;
+#endif
 
   default: mrb_assert(FALSE);
   }
@@ -1141,6 +1149,8 @@ mrb_uv_fs_access(mrb_state *mrb, mrb_value self)
   }
 }
 
+#if MRB_UV_CHECK_VERSION(1, 14, 0)
+
 static mrb_value
 mrb_uv_fs_copyfile(mrb_state *mrb, mrb_value self)
 {
@@ -1160,6 +1170,8 @@ mrb_uv_fs_copyfile(mrb_state *mrb, mrb_value self)
     return req_val;
   }
 }
+
+#endif
 
 void mrb_mruby_uv_gem_init_fs(mrb_state *mrb, struct RClass *UV)
 {
@@ -1189,7 +1201,9 @@ void mrb_mruby_uv_gem_init_fs(mrb_state *mrb, struct RClass *UV)
   mrb_define_const(mrb, _class_uv_fs, "R_OK", mrb_fixnum_value(R_OK));
   mrb_define_const(mrb, _class_uv_fs, "W_OK", mrb_fixnum_value(W_OK));
   mrb_define_const(mrb, _class_uv_fs, "X_OK", mrb_fixnum_value(X_OK));
+#if MRB_UV_CHECK_VERSION(1, 14, 0)
   mrb_define_const(mrb, _class_uv_fs, "COPYFILE_EXCL", mrb_fixnum_value(UV_FS_COPYFILE_EXCL));
+#endif
   mrb_define_method(mrb, _class_uv_fs, "write", mrb_uv_fs_write, MRB_ARGS_REQ(1) | MRB_ARGS_OPT(2));
   mrb_define_method(mrb, _class_uv_fs, "read", mrb_uv_fs_read, MRB_ARGS_REQ(0) | MRB_ARGS_OPT(2));
   mrb_define_method(mrb, _class_uv_fs, "datasync", mrb_uv_fs_fdatasync, MRB_ARGS_NONE());
@@ -1219,8 +1233,12 @@ void mrb_mruby_uv_gem_init_fs(mrb_state *mrb, struct RClass *UV)
   mrb_define_class_method(mrb, _class_uv_fs, "mkdtemp", mrb_uv_fs_mkdtemp, MRB_ARGS_REQ(1));
   mrb_define_class_method(mrb, _class_uv_fs, "access", mrb_uv_fs_access, MRB_ARGS_REQ(2));
   mrb_define_class_method(mrb, _class_uv_fs, "scandir", mrb_uv_fs_scandir, MRB_ARGS_REQ(2));
+#if MRB_UV_CHECK_VERSION(1, 14, 0)
   mrb_define_class_method(mrb, _class_uv_fs, "copyfile", mrb_uv_fs_copyfile, MRB_ARGS_REQ(2) | MRB_ARGS_OPT(1));
+#endif
+#if MRB_UV_CHECK_VERSION(1, 8, 0)
   mrb_define_class_method(mrb, _class_uv_fs, "realpath", mrb_uv_fs_realpath, MRB_ARGS_REQ(1));
+#endif
 
   /* for compatibility */
   mrb_define_class_method(mrb, _class_uv_fs, "readdir", mrb_uv_fs_scandir, MRB_ARGS_REQ(2));

--- a/src/fs.c
+++ b/src/fs.c
@@ -247,7 +247,7 @@ mrb_uv_fs_open(mrb_state *mrb, mrb_value self)
   req->data = context;
   context->fd = uv_fs_open(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_filename), arg_flags, arg_mode, fs_cb);
   if (context->fd < 0 || !fs_cb) {
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     mrb_uv_check_error(mrb, context->fd);
   }
 
@@ -275,7 +275,7 @@ mrb_uv_fs_close(mrb_state *mrb, mrb_value self)
   req->data = context;
   err = uv_fs_close(mrb_uv_current_loop(mrb), req, context->fd, fs_cb);
   if (err < 0 || !fs_cb) {
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     mrb_uv_check_error(mrb, context->fd);
   }
   return self;
@@ -312,7 +312,7 @@ mrb_uv_fs_write(mrb_state *mrb, mrb_value self)
   buf.len = arg_length;
   r = uv_fs_write(mrb_uv_current_loop(mrb), req, context->fd, &buf, 1, arg_offset, fs_cb);
   if (r < 0 || !fs_cb) {
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     mrb_uv_check_error(mrb, r);
   }
   return mrb_fixnum_value(r);
@@ -348,14 +348,14 @@ mrb_uv_fs_read(mrb_state *mrb, mrb_value self)
   len = uv_fs_read(mrb_uv_current_loop(mrb), req, context->fd, &buf, 1, arg_offset, fs_cb);
   if (len < 0) {
     mrb_free(mrb, buf.base);
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     mrb_uv_check_error(mrb, len);
   }
 
   if (!fs_cb) {
     mrb_value str = mrb_str_new(mrb, buf.base, len);
     mrb_free(mrb, buf.base);
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     return str;
   }
 
@@ -387,7 +387,7 @@ mrb_uv_fs_unlink(mrb_state *mrb, mrb_value self)
   req->data = &context;
   err = uv_fs_unlink(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_path), fs_cb);
   if (err != 0 || !fs_cb) {
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     mrb_uv_check_error(mrb, err);
   }
   return self;
@@ -419,7 +419,7 @@ mrb_uv_fs_mkdir(mrb_state *mrb, mrb_value self)
   req->data = &context;
   err = uv_fs_mkdir(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_path), arg_mode, fs_cb);
   if (err != 0 || !fs_cb) {
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     mrb_uv_check_error(mrb, err);
   }
   return self;
@@ -478,7 +478,7 @@ mrb_uv_fs_scandir(mrb_state *mrb, mrb_value self)
   err = uv_fs_scandir(mrb_uv_current_loop(mrb), req, mrb_string_value_ptr(mrb, arg_path),
                       arg_flags, mrb_nil_p(b)? NULL : _uv_fs_cb);
   if (err < 0) {
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     mrb_uv_check_error(mrb, err);
   }
   if (mrb_nil_p(b)) {
@@ -518,7 +518,7 @@ mrb_uv_fs_stat(mrb_state *mrb, mrb_value self)
   req->data = &context;
   err = uv_fs_stat(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_path), fs_cb);
   if (err != 0) {
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     mrb_uv_check_error(mrb, err);
   }
 
@@ -551,7 +551,7 @@ mrb_uv_fs_fstat(mrb_state *mrb, mrb_value self)
   req->data = &context;
   err = uv_fs_fstat(mrb_uv_current_loop(mrb), req, context->fd, fs_cb);
   if (err != 0) {
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     mrb_uv_check_error(mrb, err);
   }
 
@@ -588,7 +588,7 @@ mrb_uv_fs_lstat(mrb_state *mrb, mrb_value self)
   req->data = &context;
   err = uv_fs_lstat(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_path), fs_cb);
   if (err != 0) {
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     mrb_uv_check_error(mrb, err);
   }
 
@@ -625,7 +625,7 @@ mrb_uv_fs_rename(mrb_state *mrb, mrb_value self)
   req->data = &context;
   err = uv_fs_rename(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_path), RSTRING_PTR(arg_new_path), fs_cb);
   if (err != 0) {
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     mrb_uv_check_error(mrb, err);
   }
   return self;
@@ -652,7 +652,7 @@ mrb_uv_fs_fsync(mrb_state *mrb, mrb_value self)
   req->data = &context;
   err = uv_fs_fsync(mrb_uv_current_loop(mrb), req, context->fd, fs_cb);
   if (err != 0) {
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     mrb_uv_check_error(mrb, err);
   }
   return self;
@@ -679,7 +679,7 @@ mrb_uv_fs_fdatasync(mrb_state *mrb, mrb_value self)
   req->data = &context;
   err = uv_fs_fdatasync(mrb_uv_current_loop(mrb), req, context->fd, fs_cb);
   if (err != 0) {
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     mrb_uv_check_error(mrb, err);
   }
   return self;
@@ -707,7 +707,7 @@ mrb_uv_fs_ftruncate(mrb_state *mrb, mrb_value self)
   req->data = &context;
   err = uv_fs_ftruncate(mrb_uv_current_loop(mrb), req, context->fd, arg_offset, fs_cb);
   if (err != 0) {
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     mrb_uv_check_error(mrb, err);
   }
   return self;
@@ -740,7 +740,7 @@ mrb_uv_fs_sendfile(mrb_state *mrb, mrb_value self)
   req->data = &context;
   err = uv_fs_sendfile(mrb_uv_current_loop(mrb), req, arg_infd, arg_outfd, arg_offset, arg_length, fs_cb);
   if (err != 0) {
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     mrb_uv_check_error(mrb, err);
   }
   return self;
@@ -772,7 +772,7 @@ mrb_uv_fs_chmod(mrb_state *mrb, mrb_value self)
   req->data = &context;
   err = uv_fs_chmod(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_path), arg_mode, fs_cb);
   if (err != 0) {
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     mrb_uv_check_error(mrb, err);
   }
   return self;
@@ -803,7 +803,7 @@ mrb_uv_fs_link(mrb_state *mrb, mrb_value self)
   req->data = &context;
   err = uv_fs_link(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_path), RSTRING_PTR(arg_new_path), fs_cb);
   if (err != 0) {
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     mrb_uv_check_error(mrb, err);
   }
   return self;
@@ -831,12 +831,9 @@ mrb_uv_fs_utime(mrb_state *mrb, mrb_value self)
   req = (uv_fs_t*)mrb_malloc(mrb, sizeof(uv_fs_t));
   req->data = &context;
   err = uv_fs_utime(mrb_uv_current_loop(mrb), req, path, (double)atime, (double)mtime, mrb_nil_p(b)? NULL : _uv_fs_cb);
-  if (err < 0) {
-    mrb_free(mrb, req);
-    mrb_uv_check_error(mrb, err);
-  }
-  if (mrb_nil_p(b)) {
+  if (err < 0 || mrb_nil_p(b)) {
     mrb_uv_fs_req_free(mrb, req);
+    mrb_uv_check_error(mrb, err);
   }
   return self;
 }
@@ -860,12 +857,9 @@ mrb_uv_fs_futime(mrb_state *mrb, mrb_value self)
   req = (uv_fs_t*)mrb_malloc(mrb, sizeof(uv_fs_t));
   req->data = ctx;
   err = uv_fs_futime(mrb_uv_current_loop(mrb), req, ctx->fd, (double)atime, (double)mtime, mrb_nil_p(b)? NULL : _uv_fs_cb);
-  if (err < 0) {
-    mrb_free(mrb, req);
-    mrb_uv_check_error(mrb, err);
-  }
-  if (mrb_nil_p(b)) {
+  if (err < 0 || mrb_nil_p(b)) {
     mrb_uv_fs_req_free(mrb, req);
+    mrb_uv_check_error(mrb, err);
   }
   return self;
 }
@@ -889,14 +883,11 @@ mrb_uv_fs_fchmod(mrb_state *mrb, mrb_value self)
   req = (uv_fs_t*)mrb_malloc(mrb, sizeof(uv_fs_t));
   req->data = ctx;
   err = uv_fs_fchmod(mrb_uv_current_loop(mrb), req, ctx->fd, mode, mrb_nil_p(b)? NULL : _uv_fs_cb);
-  if (err < 0) {
-    mrb_free(mrb, req);
+  if (err < 0 || mrb_nil_p(b)) {
+    mrb_uv_fs_req_free(mrb, req);
     mrb_uv_check_error(mrb, err);
   }
 
-  if (mrb_nil_p(b)) {
-    mrb_uv_fs_req_free(mrb, req);
-  }
   return self;
 }
 
@@ -922,14 +913,11 @@ mrb_uv_fs_symlink(mrb_state *mrb, mrb_value self)
   req = (uv_fs_t*)mrb_malloc(mrb, sizeof(uv_fs_t));
   req->data = &ctx;
   err = uv_fs_symlink(mrb_uv_current_loop(mrb), req, path, new_path, flags, mrb_nil_p(b)? NULL : _uv_fs_cb);
-  if (err < 0) {
-    mrb_free(mrb, req);
+  if (err < 0 || mrb_nil_p(b)) {
+    mrb_uv_fs_req_free(mrb, req);
     mrb_uv_check_error(mrb, err);
   }
 
-  if (mrb_nil_p(b)) {
-    mrb_uv_fs_req_free(mrb, req);
-  }
   return self;
 }
 
@@ -955,7 +943,7 @@ mrb_uv_fs_readlink(mrb_state *mrb, mrb_value self)
   req->data = &ctx;
   err = uv_fs_readlink(mrb_uv_current_loop(mrb), req, path, mrb_nil_p(b)? NULL : _uv_fs_cb);
   if (err < 0) {
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     mrb_uv_check_error(mrb, err);
   }
 
@@ -991,7 +979,7 @@ mrb_uv_fs_realpath(mrb_state *mrb, mrb_value self)
   req->data = &ctx;
   err = uv_fs_realpath(mrb_uv_current_loop(mrb), req, path, mrb_nil_p(b)? NULL : _uv_fs_cb);
   if (err < 0) {
-    mrb_free(mrb, req);
+    mrb_uv_fs_req_free(mrb, req);
     mrb_uv_check_error(mrb, err);
   }
 
@@ -1020,14 +1008,11 @@ mrb_uv_fs_chown(mrb_state *mrb, mrb_value self)
   req = (uv_fs_t*)mrb_malloc(mrb, sizeof(uv_fs_t));
   req->data = &ctx;
   err = uv_fs_chown(mrb_uv_current_loop(mrb), req, path, (uv_uid_t)uid, (uv_gid_t)gid, mrb_nil_p(b)? NULL : _uv_fs_cb);
-  if (err < 0) {
-    mrb_free(mrb, req);
+  if (err < 0 || mrb_nil_p(b)) {
+    mrb_uv_fs_req_free(mrb, req);
     mrb_uv_check_error(mrb, err);
   }
 
-  if (mrb_nil_p(b)) {
-    mrb_uv_fs_req_free(mrb, req);
-  }
   return self;
 }
 
@@ -1046,14 +1031,11 @@ mrb_uv_fs_fchown(mrb_state *mrb, mrb_value self)
   req = (uv_fs_t*)mrb_malloc(mrb, sizeof(uv_fs_t));
   req->data = ctx;
   err = uv_fs_fchown(mrb_uv_current_loop(mrb), req, ctx->fd, (uv_uid_t)uid, (uv_gid_t)gid, mrb_nil_p(b)? NULL : _uv_fs_cb);
-  if (err < 0) {
-    mrb_free(mrb, req);
+  if (err < 0 || mrb_nil_p(b)) {
+    mrb_uv_fs_req_free(mrb, req);
     mrb_uv_check_error(mrb, err);
   }
 
-  if (mrb_nil_p(b)) {
-    mrb_uv_fs_req_free(mrb, req);
-  }
   return self;
 }
 

--- a/src/fs.c
+++ b/src/fs.c
@@ -448,9 +448,9 @@ mrb_uv_fs_rmdir(mrb_state *mrb, mrb_value self)
   req = (uv_fs_t*) mrb_malloc(mrb, sizeof(uv_fs_t));
   memset(req, 0, sizeof(uv_fs_t));
   req->data = &context;
-  err = uv_fs_rmdir(mrb_uv_current_loop(mrb), req, RSTRING_PTR(arg_path), fs_cb);
+  err = uv_fs_rmdir(mrb_uv_current_loop(mrb), req, mrb_string_value_ptr(mrb, arg_path), fs_cb);
   if (err != 0 || !fs_cb) {
-    mrb_free(mrb, req);
+    mrb_uv_fs_free(mrb, req);
     mrb_uv_check_error(mrb, err);
   }
   return self;

--- a/src/handle.c
+++ b/src/handle.c
@@ -5,18 +5,23 @@
 
 
 mrb_value
-mrb_uv_current_loop(mrb_state *mrb) {
+mrb_uv_current_loop_obj(mrb_state *mrb) {
   return mrb_iv_get(
       mrb, mrb_const_get(
           mrb, mrb_obj_value(mrb->object_class), mrb_intern_lit(mrb, "UV")),
       mrb_intern_lit(mrb, "current_loop"));
 }
 
+uv_loop_t*
+mrb_uv_current_loop(mrb_state *mrb) {
+  return (uv_loop_t*)mrb_uv_get_ptr(mrb, mrb_uv_current_loop_obj(mrb), &mrb_uv_loop_type);
+}
+
 static uv_loop_t*
 get_loop(mrb_state *mrb, mrb_value *v)
 {
   if(mrb_nil_p(*v)) {
-    *v = mrb_uv_current_loop(mrb);
+    *v = mrb_uv_current_loop_obj(mrb);
   }
   mrb_assert(!mrb_nil_p(*v));
   return (uv_loop_t*)mrb_uv_get_ptr(mrb, *v, &mrb_uv_loop_type);

--- a/src/handle.c
+++ b/src/handle.c
@@ -340,17 +340,11 @@ mrb_uv_pipe_connect(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_uv_pipe_bind(mrb_state *mrb, mrb_value self)
 {
-  mrb_value arg_name;
   mrb_uv_handle* context = (mrb_uv_handle*)mrb_uv_get_ptr(mrb, self, &mrb_uv_handle_type);
   const char* name;
 
-  mrb_get_args(mrb, "S", &arg_name);
-  if (mrb_nil_p(arg_name) || mrb_type(arg_name) != MRB_TT_STRING) {
-    mrb_raise(mrb, E_ARGUMENT_ERROR, "invalid argument");
-  }
-  name = RSTRING_PTR(arg_name);
-
-  mrb_uv_check_error(mrb, uv_pipe_bind((uv_pipe_t*)&context->handle, name ? name : ""));
+  mrb_get_args(mrb, "z", &name);
+  mrb_uv_check_error(mrb, uv_pipe_bind((uv_pipe_t*)&context->handle, name));
   return self;
 }
 
@@ -1558,14 +1552,15 @@ mrb_uv_fs_poll_init(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_uv_fs_poll_start(mrb_state *mrb, mrb_value self)
 {
-  mrb_value arg_path, b;
+  char const *arg_path;
+  mrb_value b;
   mrb_int arg_interval;
   mrb_uv_handle* context = (mrb_uv_handle*)mrb_uv_get_ptr(mrb, self, &mrb_uv_handle_type);
 
-  mrb_get_args(mrb, "&Si", &b, &arg_path, &arg_interval);
+  mrb_get_args(mrb, "&zi", &b, &arg_path, &arg_interval);
   set_handle_cb(context, b);
   return mrb_fixnum_value(uv_fs_poll_start(
-      (uv_fs_poll_t*)&context->handle, _uv_fs_poll_cb, RSTRING_PTR(arg_path), arg_interval));
+      (uv_fs_poll_t*)&context->handle, _uv_fs_poll_cb, arg_path, arg_interval));
 }
 
 static mrb_value

--- a/src/handle.c
+++ b/src/handle.c
@@ -762,6 +762,7 @@ _uv_udp_send_cb(uv_udp_send_t* req, int status)
   mrb_value proc = mrb_iv_get(mrb, context->instance, mrb_intern_lit(mrb, "udp_send_cb"));
   args[0] = mrb_fixnum_value(status);
   mrb_yield_argv(mrb, proc, 0, args);
+  mrb_free(mrb, req);
 }
 
 static mrb_value
@@ -859,6 +860,7 @@ _uv_udp_recv_cb(uv_udp_t* handle, ssize_t nread, const uv_buf_t* buf, const stru
     value_addr = mrb_obj_new(mrb, _class_uv_ipaddr, 1, &value_data);
     args[0] = mrb_str_new(mrb, buf->base, nread);
     args[1] = value_addr;
+    mrb_free(mrb, buf->base);
   } else {
     args[0] = mrb_nil_value();
     args[1] = mrb_nil_value();
@@ -1750,10 +1752,8 @@ mrb_uv_write(mrb_state *mrb, mrb_value self)
   uv_write_t* req;
 
   mrb_get_args(mrb, "&S|o", &b, &arg_data, &send_handle_val);
-  if (mrb_nil_p(b)) {
-    write_cb = NULL;
-  }
   mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "write_cb"), b);
+  mrb_iv_set(mrb, self, mrb_intern_lit(mrb, "write_buf"), arg_data);
 
   buf = uv_buf_init((char*) RSTRING_PTR(arg_data), RSTRING_LEN(arg_data));
   req = (uv_write_t*) mrb_malloc(mrb, sizeof(uv_write_t));

--- a/src/mrb_uv.c
+++ b/src/mrb_uv.c
@@ -860,7 +860,7 @@ void*
 mrb_uv_get_ptr(mrb_state *mrb, mrb_value v, struct mrb_data_type const *t)
 {
   if (mrb_type(v) == MRB_TT_DATA && !DATA_PTR(v)) {
-    mrb_raise(mrb, E_UV_ERROR, "already destroyed data");
+    mrb_raise(mrb, E_UV_ERROR, "uninitialized or already destroyed data");
   }
   return mrb_data_get_ptr(mrb, v, t);
 }

--- a/src/mrb_uv.c
+++ b/src/mrb_uv.c
@@ -212,8 +212,9 @@ mrb_uv_req_current(mrb_state *mrb, mrb_value blk, mrb_value *result)
       ret = mrb_uv_req_alloc(mrb);
       mrb_iv_set(mrb, target, sym, ret->instance);
     } else {
-      ret = ((mrb_uv_req_t*)DATA_PTR(req));
+      ret = (mrb_uv_req_t*)mrb_uv_get_ptr(mrb, req, &req_type);
     }
+    req = ret->instance;
 
     if (mrb_nil_p(cur_yarn)) {
       *result = ret->instance;
@@ -591,7 +592,7 @@ mrb_uv_ip4addr_init(mrb_state *mrb, mrb_value self)
 
   mrb_get_args(mrb, "o|o", &arg_host, &arg_port);
   if (mrb_type(arg_host) == MRB_TT_STRING && !mrb_nil_p(arg_port) && mrb_fixnum_p(arg_port)) {
-    mrb_uv_check_error(mrb, uv_ip4_addr((const char*) RSTRING_PTR(arg_host), mrb_fixnum(arg_port), &vaddr));
+    mrb_uv_check_error(mrb, uv_ip4_addr(mrb_str_to_cstr(mrb, arg_host), mrb_fixnum(arg_port), &vaddr));
     addr = (struct sockaddr_in*) mrb_malloc(mrb, sizeof(struct sockaddr_in));
     memcpy(addr, &vaddr, sizeof(struct sockaddr_in));
   } else if (mrb_type(arg_host) == MRB_TT_DATA) {
@@ -685,7 +686,7 @@ mrb_uv_ip6addr_init(mrb_state *mrb, mrb_value self)
 
   mrb_get_args(mrb, "o|o", &arg_host, &arg_port);
   if (mrb_type(arg_host) == MRB_TT_STRING && !mrb_nil_p(arg_port) && mrb_fixnum_p(arg_port)) {
-    mrb_uv_check_error(mrb, uv_ip6_addr((const char*) RSTRING_PTR(arg_host), mrb_fixnum(arg_port), &vaddr));
+    mrb_uv_check_error(mrb, uv_ip6_addr(mrb_str_to_cstr(mrb, arg_host), mrb_fixnum(arg_port), &vaddr));
     addr = (struct sockaddr_in6*) mrb_malloc(mrb, sizeof(struct sockaddr_in6));
     memcpy(addr, &vaddr, sizeof(struct sockaddr_in6));
   } else if (mrb_type(arg_host) == MRB_TT_DATA) {

--- a/src/mrb_uv.c
+++ b/src/mrb_uv.c
@@ -771,13 +771,15 @@ static mrb_value
 mrb_uv_addrinfo_next(mrb_state *mrb, mrb_value self)
 {
   struct addrinfo const* addr = addrinfo_ptr(mrb, self);
+  struct RClass* _class_uv, *_class_uv_addrinfo;
+  mrb_value c;
 
   if (!addr->ai_next) { return mrb_nil_value(); }
 
-  struct RClass* _class_uv = mrb_module_get(mrb, "UV");
-  struct RClass* _class_uv_addrinfo = mrb_class_get_under(mrb, _class_uv, "Addrinfo");
+  _class_uv = mrb_module_get(mrb, "UV");
+  _class_uv_addrinfo = mrb_class_get_under(mrb, _class_uv, "Addrinfo");
 
-  mrb_value c = mrb_obj_new(mrb, _class_uv_addrinfo, 0, NULL);
+  c = mrb_obj_new(mrb, _class_uv_addrinfo, 0, NULL);
   mrb_iv_set(mrb, c, mrb_intern_lit(mrb, "parent_addrinfo"), self);
   DATA_PTR(c) = addr->ai_next;
   DATA_TYPE(c) = &uv_addrinfo_nofree_type;
@@ -939,10 +941,10 @@ mrb_uv_process_title(mrb_state *mrb, mrb_value self)
 static mrb_value
 mrb_uv_process_title_set(mrb_state *mrb, mrb_value self)
 {
-  char *z;
+  char const *z;
   mrb_get_args(mrb, "z", &z);
 
-  uv_set_process_title(z);
+  mrb_uv_check_error(mrb, uv_set_process_title(z));
   return mrb_uv_process_title(mrb, self);
 }
 
@@ -1143,7 +1145,7 @@ mrb_uv_queue_work(mrb_state *mrb, mrb_value self)
 
   req_val = mrb_uv_req_alloc(mrb, UV_WORK, blk);
   req = (mrb_uv_req_t*)DATA_PTR(req_val);
-  mrb_iv_set(mrb, req->instance, mrb_intern_lit(mrb, "cfunc_cb"), cfunc);
+  mrb_iv_set(mrb, req_val, mrb_intern_lit(mrb, "cfunc_cb"), cfunc);
   mrb_uv_check_error(mrb, uv_queue_work(
       uv_default_loop(), (uv_work_t*)&req->req, mrb_uv_work_cb, mrb_uv_after_work_cb));
   mrb_uv_gc_protect(mrb, req_val);

--- a/src/mrb_uv.c
+++ b/src/mrb_uv.c
@@ -1284,10 +1284,12 @@ mrb_uv_after_work_cb(uv_work_t *uv_req, int err)
 {
   mrb_uv_req_t *req = (mrb_uv_req_t*)uv_req->data;
   mrb_state *mrb = req->mrb;
+  mrb_value p = mrb_iv_get(mrb, req->instance, mrb_intern_lit(mrb, "uv_cb"));
 
-  mrb_yield_argv(mrb, mrb_iv_get(mrb, req->instance, mrb_intern_lit(mrb, "uv_cb")), 0, NULL);
-  mrb_uv_check_error(mrb, err);
+  mrb_gc_protect(mrb, p);
+  mrb_yield_argv(mrb, p, 0, NULL);
   mrb_uv_req_release(mrb, req->instance);
+  mrb_uv_check_error(mrb, err);
 }
 
 static mrb_value

--- a/src/mrb_uv.c
+++ b/src/mrb_uv.c
@@ -334,28 +334,32 @@ static mrb_value
 mrb_uv_fs_req_result(mrb_state *mrb, mrb_value self)
 {
   mrb_uv_req_t *req = (mrb_uv_req_t*)mrb_uv_get_ptr(mrb, self, &req_type);
-  return mrb_fixnum_value(uv_fs_get_result((uv_fs_t*)&req->req));
+  if (req->req.req.type != UV_FS) { mrb_raise(mrb, E_TYPE_ERROR, "not fs request"); }
+  return mrb_fixnum_value(uv_fs_get_result(&req->req.fs));
 }
 
 static mrb_value
 mrb_uv_fs_req_statbuf(mrb_state *mrb, mrb_value self)
 {
   mrb_uv_req_t *req = (mrb_uv_req_t*)mrb_uv_get_ptr(mrb, self, &req_type);
-  return mrb_uv_create_stat(mrb, uv_fs_get_statbuf((uv_fs_t*)&req->req));
+  if (req->req.req.type != UV_FS) { mrb_raise(mrb, E_TYPE_ERROR, "not fs request"); }
+  return mrb_uv_create_stat(mrb, uv_fs_get_statbuf(&req->req.fs));
 }
 
 static mrb_value
 mrb_uv_fs_req_path(mrb_state *mrb, mrb_value self)
 {
   mrb_uv_req_t *req = (mrb_uv_req_t*)mrb_uv_get_ptr(mrb, self, &req_type);
-  return mrb_str_new_cstr(mrb, uv_fs_get_path((uv_fs_t*)&req->req));
+  if (req->req.req.type != UV_FS) { mrb_raise(mrb, E_TYPE_ERROR, "not fs request"); }
+  return mrb_str_new_cstr(mrb, uv_fs_get_path(&req->req.fs));
 }
 
 static mrb_value
 mrb_uv_fs_req_type(mrb_state *mrb, mrb_value self)
 {
   mrb_uv_req_t *req = (mrb_uv_req_t*)mrb_uv_get_ptr(mrb, self, &req_type);
-  return mrb_fixnum_value(uv_fs_get_type((uv_fs_t*)&req->req));
+  if (req->req.req.type != UV_FS) { mrb_raise(mrb, E_TYPE_ERROR, "not fs request"); }
+  return mrb_fixnum_value(uv_fs_get_type(&req->req.fs));
 }
 
 #endif
@@ -1625,7 +1629,6 @@ mrb_mruby_uv_gem_init(mrb_state* mrb) {
   struct RClass* _class_uv_ip4addr;
   struct RClass* _class_uv_ip6addr;
   struct RClass* _class_uv_req;
-  struct RClass* _class_uv_fs_req;
   struct RClass* _class_uv_os;
 #if MRB_UV_CHECK_VERSION(1, 9, 0)
   struct RClass* _class_uv_passwd;
@@ -1786,15 +1789,13 @@ mrb_mruby_uv_gem_init(mrb_state* mrb) {
   mrb_define_method(mrb, _class_uv_req, "cancel", mrb_uv_cancel, MRB_ARGS_NONE());
   mrb_define_method(mrb, _class_uv_req, "type", mrb_uv_req_type, MRB_ARGS_NONE());
   mrb_define_method(mrb, _class_uv_req, "type_name", mrb_uv_req_type_name, MRB_ARGS_NONE());
-  mrb_undef_class_method(mrb, _class_uv_req, "new");
-
-  _class_uv_fs_req = mrb_define_class_under(mrb, _class_uv, "FsReq", _class_uv_req);
 #if MRB_UV_CHECK_VERSION(1, 19, 0)
-  mrb_define_method(mrb, _class_uv_fs_req, "path", mrb_uv_fs_req_path, MRB_ARGS_NONE());
-  mrb_define_method(mrb, _class_uv_fs_req, "result", mrb_uv_fs_req_result, MRB_ARGS_NONE());
-  mrb_define_method(mrb, _class_uv_fs_req, "statbuf", mrb_uv_fs_req_statbuf, MRB_ARGS_NONE());
-  mrb_define_method(mrb, _class_uv_fs_req, "type", mrb_uv_fs_req_type, MRB_ARGS_NONE());
+  mrb_define_method(mrb, _class_uv_req, "path", mrb_uv_fs_req_path, MRB_ARGS_NONE());
+  mrb_define_method(mrb, _class_uv_req, "result", mrb_uv_fs_req_result, MRB_ARGS_NONE());
+  mrb_define_method(mrb, _class_uv_req, "statbuf", mrb_uv_fs_req_statbuf, MRB_ARGS_NONE());
+  mrb_define_method(mrb, _class_uv_req, "type", mrb_uv_fs_req_type, MRB_ARGS_NONE());
 #endif
+  mrb_undef_class_method(mrb, _class_uv_req, "new");
 
   _class_uv_os = mrb_define_module_under(mrb, _class_uv, "OS");
 #if MRB_UV_CHECK_VERSION(1, 6, 0)

--- a/src/mrb_uv.c
+++ b/src/mrb_uv.c
@@ -21,10 +21,10 @@ mrb_uv_gc_table_get(mrb_state *mrb)
 void
 mrb_uv_gc_table_clean(mrb_state *mrb, uv_loop_t *target)
 {
-  int i, new_i;
+  int i, new_i = 0;
   mrb_value t = mrb_uv_gc_table_get(mrb);
   mrb_value const *ary = RARRAY_PTR(t);
-  for (i = 0, new_i = 0; i < RARRAY_LEN(t); ++i) {
+  for (i = 0; i < RARRAY_LEN(t); ++i) {
     mrb_value const v = ary[i];
     if (!DATA_PTR(v) ||
         (DATA_TYPE(v) == &mrb_uv_handle_type && ((mrb_uv_handle*)DATA_PTR(v))->handle.loop == target) ||
@@ -33,7 +33,6 @@ mrb_uv_gc_table_clean(mrb_state *mrb, uv_loop_t *target)
     }
   }
   mrb_ary_resize(mrb, t, new_i);
-  mrb_full_gc(mrb);
   uv_run(uv_default_loop(), UV_RUN_ONCE);
 }
 

--- a/src/mrb_uv.h
+++ b/src/mrb_uv.h
@@ -100,4 +100,11 @@ mrb_value mrb_uv_from_uint64(mrb_state *mrb, uint64_t v);
 #  endif
 #endif
 
+#define MRB_UV_CHECK_VERSION(maj, min, pat)                             \
+  ((UV_VERSION_MAJOR >  (maj)) ||                                       \
+   (UV_VERSION_MAJOR >= (maj) && UV_VERSION_MINOR >  (min)) ||          \
+   (UV_VERSION_MAJOR >= (maj) && UV_VERSION_MINOR >= (min) && UV_VERSION_PATCH >= (pat))) \
+
+mrb_value mrb_uv_current_loop(mrb_state *mrb);
+
 #endif

--- a/src/mrb_uv.h
+++ b/src/mrb_uv.h
@@ -105,6 +105,7 @@ mrb_value mrb_uv_from_uint64(mrb_state *mrb, uint64_t v);
    (UV_VERSION_MAJOR >= (maj) && UV_VERSION_MINOR >  (min)) ||          \
    (UV_VERSION_MAJOR >= (maj) && UV_VERSION_MINOR >= (min) && UV_VERSION_PATCH >= (pat))) \
 
-mrb_value mrb_uv_current_loop(mrb_state *mrb);
+uv_loop_t* mrb_uv_current_loop(mrb_state *mrb);
+mrb_value mrb_uv_current_loop_obj(mrb_state *mrb);
 
 #endif

--- a/src/mrb_uv.h
+++ b/src/mrb_uv.h
@@ -108,4 +108,6 @@ mrb_value mrb_uv_from_uint64(mrb_state *mrb, uint64_t v);
 uv_loop_t* mrb_uv_current_loop(mrb_state *mrb);
 mrb_value mrb_uv_current_loop_obj(mrb_state *mrb);
 
+void mrb_uv_close_handle_belongs_to_vm(uv_handle_t * h, void *arg);
+
 #endif

--- a/src/mrb_uv.h
+++ b/src/mrb_uv.h
@@ -20,6 +20,8 @@
 #include <mruby/class.h>
 #include <mruby/variable.h>
 
+#include <mruby/uv.h>
+
 #ifndef MRUBY_VERSION
 #define mrb_module_get mrb_class_get
 #define mrb_uv_args_int int
@@ -66,18 +68,21 @@ mrb_value mrb_uv_gc_table_get(mrb_state *mrb);
 void mrb_uv_gc_table_clean(mrb_state *mrb, uv_loop_t *l);
 void mrb_uv_gc_protect(mrb_state *mrb, mrb_value v);
 
-mrb_value mrb_uv_req_alloc(mrb_state *mrb, uv_req_type t, mrb_value proc);
-void mrb_uv_req_release(mrb_state *mrb, mrb_value v);
-
-typedef struct mrb_uv_req_t {
+struct mrb_uv_req_t {
   mrb_state *mrb;
   mrb_value instance, block;
-  uv_req_t req;
-} mrb_uv_req_t;
+  mrb_bool is_used:1;
+  union uv_any_req req;
+};
+
+void mrb_uv_req_clear(mrb_uv_req_t *req);
+mrb_uv_req_t *mrb_uv_req_current(mrb_state *mrb, mrb_value blk, mrb_value *result);
+void mrb_uv_req_yield(mrb_uv_req_t *req, mrb_int argc, mrb_value const *argv);
+void mrb_uv_req_set_buf(mrb_uv_req_t *req, uv_buf_t *buf, mrb_value str);
 
 typedef struct {
   mrb_state* mrb;
-  mrb_value instance;
+  mrb_value instance, block;
   uv_handle_t handle;
 } mrb_uv_handle;
 
@@ -109,5 +114,8 @@ uv_loop_t* mrb_uv_current_loop(mrb_state *mrb);
 mrb_value mrb_uv_current_loop_obj(mrb_state *mrb);
 
 void mrb_uv_close_handle_belongs_to_vm(uv_handle_t * h, void *arg);
+
+mrb_value mrb_uv_create_error(mrb_state *mrb, int err);
+mrb_value mrb_uv_create_status(mrb_state *mrb, int status);
 
 #endif

--- a/src/thread.c
+++ b/src/thread.c
@@ -91,9 +91,8 @@ _uv_thread_proc(void *arg)
   proc = mrb_iv_get(mrb, context->instance, mrb_intern_lit(mrb, "thread_proc"));
   thread_arg = mrb_iv_get(mrb, context->instance, mrb_intern_lit(mrb, "thread_arg"));
   if (!mrb_nil_p(proc)) {
-    mrb_value args[1];
-    args[0] = thread_arg;
-    mrb_yield_argv(mrb, proc, 1, args);
+    mrb_value const arg = thread_arg;
+    mrb_yield_argv(mrb, proc, 1, &arg);
   }
 }
 

--- a/test/callback.rb
+++ b/test/callback.rb
@@ -178,7 +178,7 @@ assert_uv 'UV.getaddrinfo' do
   assert_equal :getaddrinfo, req.type
 
   # getaddrinfo without callback
-  assert_raise(ArgumentError) { UV.getaddrinfo 'www.google.com', 'http' }
+  assert_raise(ArgumentError) { UV.getaddrinfo 'example.com', 'http' }
 end
 
 assert_uv 'UV.getnameinfo' do

--- a/test/callback.rb
+++ b/test/callback.rb
@@ -449,6 +449,8 @@ assert_uv 'UV::FS::Event change' do
 
   UV::FS.mkdir 'foo-bar'
   f = UV::FS.open "foo-bar/foo.txt", UV::FS::O_CREAT|UV::FS::O_WRONLY, UV::FS::S_IWRITE | UV::FS::S_IREAD
+  f.write "test\n"
+  f.close
 
   ev = UV::FS::Event.new
   ev.start 'foo-bar/foo.txt', 0 do |change_path, change_ev|
@@ -461,9 +463,9 @@ assert_uv 'UV::FS::Event change' do
   assert_equal 'foo-bar/foo.txt', ev.path
 
   t = UV::Timer.new
-  t.start 10, 0 do
-    f.write "test\n"
-    f.sync
+  t.start UV_INTERVAL, 0 do
+    f = UV::FS.open "foo-bar/foo.txt", UV::FS::O_TRUNC|UV::FS::O_WRONLY, UV::FS::S_IWRITE | UV::FS::S_IREAD
+    f.write "test change\n"
     f.close
   end
 end

--- a/test/callback.rb
+++ b/test/callback.rb
@@ -492,8 +492,13 @@ assert_uv 'Process' do
     ps.close
     remove_uv_test_tmpfile
   end
+  str = ''
   out.read_start do |b|
-    assert_equal "foo-bar/foo.txt:test\n", b
+    if b != :eof
+      str << b
+      next
+    end
+    assert_equal "foo-bar/foo.txt:test\n", str
     out.close
   end
 
@@ -502,8 +507,13 @@ assert_uv 'Process' do
     assert_equal 0, x
     assert_equal 0, sig
   end
+  env_str = ''
   env_out.read_start do |b|
-    assert_equal "test\n", b
+    if b != :eof
+      env_str << b
+      next
+    end
+    assert_equal "test\n", env_str
     env_out.close
   end
 end

--- a/test/uv.c
+++ b/test/uv.c
@@ -25,12 +25,30 @@ static mrb_value get_work_result(mrb_state *mrb, mrb_value self) {
   return mrb_fixnum_value(count);
 }
 
-void mrb_mruby_uv_gem_test(mrb_state* mrb) {
-  int argc = 1;
-  char *argv[2] = {NULL, NULL};
+#define MRB_UV_SETUP_ARGS()                             \
+  do {                                                  \
+    int argc = 1;                                       \
+    static char proc_title_buf[PATH_MAX];               \
+    char const * argv[] = {proc_title_buf, NULL};       \
+                                                        \
+    strcpy(proc_title_buf, "mrbtest");                  \
+    mrb_uv_setup_args(NULL, &argc, (char **)argv, 0);   \
+  } while(0)                                            \
 
-  argv[0] = strdup("mrbtest"); // will not free until program exit
-  mrb_uv_setup_args(mrb, &argc, (char **)argv, 0);
+#if defined(__clang__) ||                                               \
+  defined(__GNUC__) ||                                                  \
+  defined(__INTEL_COMPILER) ||                                          \
+  defined(__SUNPRO_C)
+#define UV_DESTRUCTOR
+__attribute__((destructor)) static void setup_args() {
+  MRB_UV_SETUP_ARGS();
+}
+#endif
+
+void mrb_mruby_uv_gem_test(mrb_state* mrb) {
+#ifndef UV_DESTRUCTOR
+  MRB_UV_SETUP_ARGS();
+#endif
 
   mrb_define_method(mrb, mrb->object_class, "raise_signal", raise_signal, MRB_ARGS_REQ(1));
   mrb_define_method(mrb, mrb->kernel_module, "get_work_result", get_work_result, MRB_ARGS_NONE());

--- a/test/uv.rb
+++ b/test/uv.rb
@@ -158,7 +158,7 @@ assert 'UV.getaddrinfo ipv4' do
 end
 
 assert 'UV.getaddrinfo ipv6' do
-  UV::getaddrinfo('localhost', 'http', {:ai_family => :ipv6}) do |x, info|
+  UV::getaddrinfo('example.com', 'http', {:ai_family => :ipv6}) do |x, info|
     assert_kind_of UV::Ip6Addr, info.addr
   end
   UV::run()

--- a/test/uv.rb
+++ b/test/uv.rb
@@ -142,6 +142,17 @@ assert 'UV::Loop#configure' do
   UV.default_loop.configure block_signal: UV::Signal::SIGPROF
 end
 
+assert 'UV::Loop#make_current' do
+  assert_equal UV.default_loop, UV.current_loop
+
+  l = UV::Loop.new
+  l.make_current
+  assert_equal l, UV.current_loop
+
+  UV.default_loop.make_current
+  assert_equal UV.default_loop, UV.current_loop
+end
+
 assert 'UV::SOMAXCONN' do
   assert_kind_of Fixnum, UV::SOMAXCONN
 end

--- a/test/uv.rb
+++ b/test/uv.rb
@@ -1,8 +1,6 @@
 assert('UV.guess_handle') do
-  skip if UV.guess_handle(0) == :pipe
-  assert_equal :tty, UV.guess_handle(0)
-  assert_equal :tty, UV.guess_handle(1)
-  assert_equal :tty, UV.guess_handle(2)
+  h = UV.guess_handle(0)
+  assert_true h == :pipe || h == :tty || h == :unknown
 end
 
 assert('UV::TTY') do

--- a/test/yarn.rb
+++ b/test/yarn.rb
@@ -25,3 +25,18 @@ assert 'Yarn process' do
 
   assert_nil y.error
 end
+
+assert 'Yarn DNS' do
+  y = UV::Yarn.new do
+    host, service = UV.getnameinfo(UV::Ip4Addr.new('127.0.0.1', 80))
+    assert_kind_of String, host
+    assert_equal 'http', service
+
+    err, a = UV.getaddrinfo 'example.com', 'http'
+    assert_nil err
+    assert_equal 80, a.addr.sin_port
+  end
+  y.start
+  y.loop.run
+  assert_nil y.error
+end

--- a/test/yarn.rb
+++ b/test/yarn.rb
@@ -16,8 +16,9 @@ end
 assert 'Yarn process' do
   y = UV::Yarn.new do
     str = UV.quote('echo test')
-    __t_printstr__ str
     assert_equal "test\n", str
+    str = UV.quote('echo test1')
+    assert_equal "test1\n", str
   end
   y.start
   y.loop.run

--- a/test/yarn.rb
+++ b/test/yarn.rb
@@ -1,0 +1,12 @@
+assert "Yarn" do
+  y = UV::Yarn.new do
+    t = UV.current_loop.now
+    UV.sleep 0.1
+    assert_true (UV.current_loop.now - t) >= 100
+    UV.sleep 0.1
+    assert_true (UV.current_loop.now - t) >= 200
+  end
+
+  y.start
+  y.loop.run
+end

--- a/test/yarn.rb
+++ b/test/yarn.rb
@@ -1,12 +1,26 @@
-assert "Yarn" do
+assert "Yarn sleep" do
   y = UV::Yarn.new do
-    t = UV.current_loop.now
+    t = y.loop.now
     UV.sleep 0.1
-    assert_true (UV.current_loop.now - t) >= 100
+    assert_true (y.loop.now - t) >= 100
     UV.sleep 0.1
-    assert_true (UV.current_loop.now - t) >= 200
+    assert_true (y.loop.now - t) >= 200
   end
 
   y.start
   y.loop.run
+
+  assert_nil y.error
+end
+
+assert 'Yarn process' do
+  y = UV::Yarn.new do
+    str = UV.quote('echo test')
+    __t_printstr__ str
+    assert_equal "test\n", str
+  end
+  y.start
+  y.loop.run
+
+  assert_nil y.error
 end


### PR DESCRIPTION
- Fix leaks found by mgem CI: https://103.128.221.202.static.iijgio.jp/jenkins/view/0-master-mrbgem/job/master-mruby-uv/lastFailedBuild/console.
- Update supported libuv version to 1.19.1.
- Add supports of old libuv 1.x with preprocessors.
- Introduce green thread as `UV::Yarn` .
- Use `UVError`s to pass error to callbacks.
- Better support of `uv_process_option_t` .
