### PR TITLE
Fixes for libuv-1.0 build.

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -16,6 +16,7 @@ MRuby::Gem::Specification.new('mruby-uv') do |spec|
   def self.bundle_uv
     visualcpp = ENV['VisualStudioVersion'] || ENV['VSINSTALLDIR']
 
+    # version = '1.0.0'
     version = '1.19.1'
     libuv_dir = "#{build_dir}/libuv-#{version}"
     libuv_lib = libfile "#{libuv_dir}/.libs/libuv"

--- a/src/fs.c
+++ b/src/fs.c
@@ -1,7 +1,6 @@
 #include "mruby/uv.h"
 #include "mrb_uv.h"
 #include <fcntl.h>
-#include <stdlib.h>
 
 /*
  * UV::Stat

--- a/src/fs.c
+++ b/src/fs.c
@@ -83,7 +83,7 @@ mrb_uv_fs_free(mrb_state *mrb, void *p)
   if (ctx) {
     uv_fs_t req;
     req.data = ctx;
-    uv_fs_close(NULL, &req, ctx->fd, NULL);
+    uv_fs_close(uv_default_loop(), &req, ctx->fd, NULL);
     mrb_free(mrb, ctx);
   }
 }

--- a/src/handle.c
+++ b/src/handle.c
@@ -1937,7 +1937,7 @@ mrb_uv_fs_event_path(mrb_state *mrb, mrb_value self)
   mrb_uv_handle *ctx = (mrb_uv_handle*)mrb_uv_get_ptr(mrb, self, &mrb_uv_handle_type);
 
   mrb_uv_check_error(mrb, uv_fs_event_getpath((uv_fs_event_t*)&ctx->handle, ret, &len));
-  return mrb_str_new(mrb, ret, len);
+  return mrb_str_new_cstr(mrb, ret);
 }
 
 /*

--- a/src/mrb_uv.c
+++ b/src/mrb_uv.c
@@ -315,7 +315,7 @@ mrb_uv_req_type_name(mrb_state *mrb, mrb_value self)
 #if MRB_UV_CHECK_VERSION(1, 19, 0)
   return mrb_symbol_value(mrb_intern_cstr(mrb, uv_req_type_name(uv_req_get_type(&req->req.req))));
 #else
-  switch(req->req.type) {
+  switch(req->req.req.type) {
 #define XX(u, l) case UV_ ## u: return symbol_value_lit(mrb, #l);
       UV_REQ_TYPE_MAP(XX)
 #undef XX
@@ -323,7 +323,7 @@ mrb_uv_req_type_name(mrb_state *mrb, mrb_value self)
     case UV_UNKNOWN_REQ: return symbol_value_lit(mrb, "unknown");
 
     default:
-      mrb_raisef(mrb, E_TYPE_ERROR, "Invalid uv_req_t type: %S", mrb_fixnum_value(req->req.type));
+      mrb_raisef(mrb, E_TYPE_ERROR, "Invalid uv_req_t type: %S", mrb_fixnum_value(req->req.req.type));
       return self;
   }
 #endif


### PR DESCRIPTION
- Use default loop in fs close.
- Fix compilation in older libuv.